### PR TITLE
Search Changes

### DIFF
--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -67,7 +67,7 @@ var Search = React.createClass({
     $.ajax({
       context: this,
       type: "GET",
-      url:  collection + '/search?q=' + this.props.searchTerm,
+      url:  collection + '/search?q=' + this.props.searchTerm + '&rows=100',
       dataType: "json",
       success: function(result) {
         this.setItems(result.hits);

--- a/src/routes/SearchPage.jsx
+++ b/src/routes/SearchPage.jsx
@@ -12,7 +12,17 @@ import SearchSidebar from '../components/Search/SearchSidebar.jsx';
 const CATHOLIC = 'Catholic Social Teaching';
 const HUMANRIGHTS = 'International Human Rights Law';
 
+import ItemActions from '../actions/ItemActions.jsx';
+import ItemStore from '../store/ItemStore.js';
+
 class SearchPage extends Component {
+  constructor() {
+    super();
+    this.state = {
+      loaded: false,
+    };
+  }
+
   listStyle(side) {
     return {
       backgroundColor: 'transparent',
@@ -29,7 +39,21 @@ class SearchPage extends Component {
     }
   }
 
+  componentWillMount() {
+    ItemActions.preLoadItems();
+    var func = this.preLoadFinished.bind(this);
+    ItemStore.on("PreLoadFinished", func);
+  }
+
+  preLoadFinished() {
+    this.setState({loaded: true});
+  }
+
   render() {
+    if (!this.state.loaded) {
+      return (<p>Loading....</p>);
+    }
+
     return (
       <div>
         <Header/>


### PR DESCRIPTION
* Display name of parent article instead of individual paragraph's name
* Expand/collapse on clicking name instead of adding to notebook
* Display accurate paragraph number based on order metadata
* Hide items that don't have parents
* Increase results requested on search page to 100 instead of using Honeycomb's default of 12