### PR TITLE
DEC-867: As a user of the Vatican research database, I need to be able to view a single document by itself

### DIFF
--- a/src/components/Document/Document.jsx
+++ b/src/components/Document/Document.jsx
@@ -13,13 +13,9 @@ class Document extends Component {
     super(props);
     this._item = ItemStore.getItem(props.documentId);
     this._parent = ItemStore.getItemParent(this._item);
-  }
-
-  style() {
-    return {
-      overflow: "scroll",
-      height: "400px",
-      clear: "both",
+    if(this._parent == null){
+      // If the item has no parents, we assume it is a parent.
+      this._parent = this._item;
     }
   }
 
@@ -38,9 +34,9 @@ class Document extends Component {
           { this.props.children }
         </div>
         <Title item={this._parent} />
-        <CopyrightNotification item={ this._parent } />        
+        <CopyrightNotification item={ this._parent } />
         <hr />
-        <div style={ this.style() } >
+        <div style={ this.props.bodyStyle } >
           { this.paragraphs() }
         </div>
       </div>
@@ -53,5 +49,13 @@ Document.propTypes = {
   item: React.PropTypes.object,
   parent: React.PropTypes.object,
 }
+
+Document.defaultProps = {
+  bodyStyle: {
+    fontSize: "16px",
+    maxWidth: "32.5em", // Should put it between 70-75 characters at 1em (16px)
+    margin: "0 auto",
+  }
+};
 
 export default Document;

--- a/src/components/Document/DocumentCard.jsx
+++ b/src/components/Document/DocumentCard.jsx
@@ -1,10 +1,27 @@
 'use strict'
 import React, { Component, PropTypes } from 'react';
+import ReactDOM from 'react-dom';
 import ItemStore from '../../store/ItemStore.js';
 import CurrentParagraph from '../Document/CurrentParagraph.jsx';
+import DocumentDialog from '../Document/DocumentDialog.jsx';
 import Title from '../Document/Title.jsx';
 import mui from 'material-ui';
+import Colors from 'material-ui/lib/styles/colors';
+import IconButton from 'material-ui/lib/icon-button';
+import MoreVertIcon from 'material-ui/lib/svg-icons/navigation/more-vert';
+import IconMenu from 'material-ui/lib/menus/icon-menu';
+import MenuItem from 'material-ui/lib/menus/menu-item';
 
+
+const iconButtonElement = (
+  <IconButton
+    touch={true}
+    tooltip="more"
+    tooltipPosition="bottom-left"
+  >
+    <MoreVertIcon color={Colors.grey400} />
+  </IconButton>
+);
 
 class DocumentCard extends Component {
   constructor(props) {
@@ -13,25 +30,23 @@ class DocumentCard extends Component {
     this.primaryAction = this.primaryAction.bind(this);
     this._item = this.props.item;
     this._parent = ItemStore.getItemParent(this._item);
-
-    this.state = { menuOpen: false }
   }
 
   primaryAction(event) {
     this.props.primaryAction(event, this._item);
   }
 
-  menuClick() {
-    this.setState({ menuOpen: !this.state.menuOpen });
-  }
-
-  menu() {
-    if (this.state.menuOpen) {
-      return (<mui.Menu animated={true}>
-        <mui.MenuItem>View Docuemnet</mui.MenuItem>
-        <mui.MenuItem>Download PDF</mui.MenuItem>
-        <mui.MenuItem>Metadata?</mui.MenuItem>
-      </mui.Menu>);
+  moreAction(event, child) {
+    switch(child.key) {
+      case "ViewDocument":
+        this.refs.DocumentDialog.handleOpen(child.props.documentId);
+        break;
+      case "DownloadPDF":
+        break;
+      case "Metadata":
+        break;
+      default:
+        break;
     }
   }
 
@@ -40,10 +55,15 @@ class DocumentCard extends Component {
 
     return (
       <div className="document">
+        <DocumentDialog ref="DocumentDialog"/>
         <div style={{ float: "right "}}>
-          <mui.FlatButton icon={ icon } onTouchTap={this.menuClick.bind(this)} />
+          <IconMenu iconButtonElement={iconButtonElement} onItemTouchTap={ this.moreAction.bind(this) }>
+            <MenuItem key="ViewDocument" documentId={ this._item.id }>View Document</MenuItem>
+            <MenuItem key="DownloadPDF">Download PDF</MenuItem>
+            <MenuItem key="Metadata">Metadata?</MenuItem>
+          </IconMenu>
         </div>
-        <div  style={{cursor: 'pointer'}} onClick={this.primaryAction}>
+        <div style={{cursor: 'pointer'}} onClick={this.primaryAction}>
           <Title item={this._parent} />
         </div>
         <CurrentParagraph item={ this._item } />

--- a/src/components/Document/DocumentDialog.jsx
+++ b/src/components/Document/DocumentDialog.jsx
@@ -1,0 +1,52 @@
+'use strict'
+import React, { Component, PropTypes } from 'react';
+import mui from 'material-ui';
+
+import Header from '../../components/StaticAssets/Header.jsx';
+import Document from '../../components/Document/Document.jsx';
+import ItemActions from '../../actions/ItemActions.jsx'
+import ItemStore from '../../store/ItemStore.js'
+
+class DocumentDialog extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: props.open,
+    };
+  }
+
+  handleOpen = (documentId) => {
+    this.setState({
+      open: true,
+      documentId: documentId
+    });
+  };
+
+  handleClose = () => {
+    this.setState({open: false});
+  };
+
+  render() {
+    const actions = [
+      <mui.FlatButton
+        label="Close"
+        keyboardFocused={true}
+        onTouchTap={this.handleClose}
+      />,
+    ];
+
+    return (
+        <mui.Dialog
+          actions={actions}
+          modal={false}
+          open={this.state.open}
+          onRequestClose={this.handleClose}
+          bodyStyle={{ overflow: 'scroll' }}
+        >
+          <Document documentId={ this.state.documentId } />
+        </mui.Dialog>
+    );
+  }
+}
+
+export default DocumentDialog;

--- a/src/components/Notebook/NotebookDocument.jsx
+++ b/src/components/Notebook/NotebookDocument.jsx
@@ -22,11 +22,19 @@ class NotebookDocument extends Component {
     }
   }
 
+  documentBodyStyle() {
+    return {
+      overflow: "scroll",
+      height: "400px",
+      clear: "both",
+    };
+  }
+
   render() {
     return (
       <div>
         <Heading title={ this.documentTitle() } />
-        <Document documentId={ this.props.document.id }>
+        <Document documentId={ this.props.document.id } bodyStyle={ this.documentBodyStyle() }>
           <a href="#" className="remove-document" onClick={ this.removeClick.bind(this) }>
             <mui.FontIcon className="material-icons">clear</mui.FontIcon>
           </a>

--- a/src/routes/DocumentPage.jsx
+++ b/src/routes/DocumentPage.jsx
@@ -1,0 +1,46 @@
+'use strict'
+import React, { Component, PropTypes } from 'react';
+import mui from 'material-ui';
+
+import Header from '../components/StaticAssets/Header.jsx';
+import Document from '../components/Document/Document.jsx';
+import ItemActions from '../actions/ItemActions.jsx'
+import ItemStore from '../store/ItemStore.js'
+
+class DocumentPage extends Component {
+  constructor() {
+    super();
+    this.state = {
+      loaded: false,
+    };
+    this.preLoadFinished = this.preLoadFinished.bind(this)
+  }
+
+  componentWillMount() {
+    ItemActions.preLoadItems();
+    ItemStore.on("PreLoadFinished", this.preLoadFinished);
+  }
+
+  preLoadFinished() {
+    this.setState({ loaded: true });
+  }
+
+  renderDocument() {
+    if (this.state.loaded) {
+      return (<Document documentId={ this.props.params.id } />);
+    } else {
+      return (<p>Loading....</p>);
+    }
+  }
+
+  render() {
+    return (
+      <mui.Paper zDepth={ 0 }>
+        <Header/>
+        { this.renderDocument() }
+      </mui.Paper>
+    );
+  }
+}
+
+export default DocumentPage;

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -10,6 +10,7 @@ import ContactPage from './ContactPage.jsx';
 import ResultPage from './ResultPage.jsx';
 import SearchPage from './SearchPage.jsx';
 import NotebookPage from './NotebookPage.jsx';
+import DocumentPage from './DocumentPage.jsx';
 
 
 export default function() {
@@ -23,6 +24,7 @@ export default function() {
         <Route path="/result" component={ ResultPage} />
         <Route path="/search" component={SearchPage} />
         <Route path="/notebook" component={NotebookPage} />
+        <Route path="/document/:id" component={DocumentPage} />
       </Route>
     </Router>
   );


### PR DESCRIPTION
Why: As a user of the Vatican research database, I need to be able to view a single document by itself.
How:
-Added a document route and created a DocumentPage that reuses the Document component to just render a single document. 
-Changed document to handle both child and parent objects. Ex: http://localhost:3020/document/8725e3487c, or http://localhost:3020/document/21c509b691
-Changed default style of the Document component to handle the common case (to work with both the page and dialog). The notebook now overrides the style to create the fixed height/scrolling view.
-Created a DocumentDialog that can be used to generically display a document object in a dialog window.
-Modified the DocumentCard to use the MUI additional actions buttons and connected the "View Document" action with the DocumentDialog. This will allow a user to view the full document with the paragraph highlighted without leaving search results.