### PR TITLE
Dec 824 part the first.  Updating Routes so they do not reload the page all the way.

### DIFF
--- a/src/components/Notebook/NotebookList.jsx
+++ b/src/components/Notebook/NotebookList.jsx
@@ -8,7 +8,7 @@ import CompareActions from '../../actions/CompareActions.js'
 import _ from 'underscore'
 import VaticanID from '../../constants/VaticanID.js';
 import HumanRightsID from '../../constants/HumanRightsID.js';
-import ItemQueryParams from '../modules/ItemQueryParams.js';
+import ItemQueryParams from '../../modules/ItemQueryParams.js';
 
 class NotebookList extends Component {
   constructor(props) {

--- a/src/components/Notebook/NotebookList.jsx
+++ b/src/components/Notebook/NotebookList.jsx
@@ -4,11 +4,11 @@ import ItemStore from '../../store/ItemStore.js'
 import CompareStore from '../../store/CompareStore.js'
 import DocumentListItem from '../Document/DocumentListItem.jsx'
 import ShareSave from '../Document/ShareSave.jsx'
-import Heading from '../Shared/Heading.jsx'
 import CompareActions from '../../actions/CompareActions.js'
 import _ from 'underscore'
 import VaticanID from '../../constants/VaticanID.js';
 import HumanRightsID from '../../constants/HumanRightsID.js';
+import ItemQueryParams from '../modules/ItemQueryParams.js';
 
 class NotebookList extends Component {
   constructor(props) {
@@ -16,11 +16,10 @@ class NotebookList extends Component {
     var allIds = CompareStore.allItems();
 
     this.documentClick = this.documentClick.bind(this);
-    this._all_items = ItemStore.getItemsByMultipleIds(allIds)
-    this._humanrights_documents = _.filter(this._all_items, function(item) {
+    this._humanrights_documents = _.filter(ItemStore.getItemsByMultipleIds(ItemQueryParams('v')), function(item) {
       return item.collection_id == HumanRightsID;
     });
-    this._vatican_douments = _.filter(this._all_items, function(item) {
+    this._vatican_douments = _.filter(ItemStore.getItemsByMultipleIds(ItemQueryParams('h')), function(item) {
       return item.collection_id == VaticanID;
     });
   }

--- a/src/components/StaticPages/SiteIndex.jsx
+++ b/src/components/StaticPages/SiteIndex.jsx
@@ -3,6 +3,9 @@ var React = require('react');
 var Header = require('../StaticAssets/Header.jsx');
 var Navigation = require('../StaticAssets/Navigation.jsx');
 var Footer = require('../StaticAssets/Footer.jsx');
+
+import { Link } from 'react-router'
+
 var SiteIndex = React.createClass({
 
   render: function() {
@@ -12,8 +15,9 @@ var SiteIndex = React.createClass({
 
 
       		<section className="search">
-            <h2><a href="/search?q=">Search The Database <i className="glyphicon glyphicon-circle-arrow-right"></i></a></h2>
-            <p><a href="/search?q=">Using the Database</a></p>
+
+            <h2><Link to="/search?q=">Search The Database <i className="glyphicon glyphicon-circle-arrow-right"></i></Link></h2>
+            <p><Link to="/search?q=">Using the Database</Link></p>
           </section>
 
 

--- a/src/routes/Page.jsx
+++ b/src/routes/Page.jsx
@@ -1,0 +1,21 @@
+'use strict'
+import React, { Component, PropTypes } from 'react';
+import ItemActions from '../actions/ItemActions.jsx'
+import ItemStore from '../store/ItemStore.js'
+
+
+class Page extends Component {
+  componentWillMount() {
+    ItemActions.preLoadItems();    
+  }
+
+  render() {
+    return (
+      <div>
+        { this.props.children }
+      </div>
+    );
+  }
+}
+
+export default Page;

--- a/src/routes/SearchPage.jsx
+++ b/src/routes/SearchPage.jsx
@@ -34,9 +34,12 @@ class SearchPage extends Component {
   }
 
   componentWillMount() {
-    ItemActions.preLoadItems();
-    var func = this.preLoadFinished.bind(this);
-    ItemStore.on("PreLoadFinished", func);
+    if (ItemStore.preLoaded()) {
+      this.preLoadFinished();
+    } else {
+      var func = this.preLoadFinished.bind(this);
+      ItemStore.on("PreLoadFinished", func);
+    }
   }
 
   preLoadFinished() {

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -11,12 +11,13 @@ import ResultPage from './ResultPage.jsx';
 import SearchPage from './SearchPage.jsx';
 import NotebookPage from './NotebookPage.jsx';
 import DocumentPage from './DocumentPage.jsx';
+import Page from './Page.jsx';
 
 
 export default function() {
   return (
     <Router history={ browserHistory }>
-      <Route path="/">
+      <Route path="/" component={ Page }>
         <IndexRoute component={ SiteIndexPage } />
         <Route path="/about" component={ AboutPage } />
         <Route path="/partners" component={ PartnersPage} />

--- a/src/store/ItemStore.js
+++ b/src/store/ItemStore.js
@@ -39,6 +39,10 @@ class ItemStore extends EventEmitter {
     }
   }
 
+  preLoaded() {
+    return (this._vatican_finished && this._human_rights_finished);
+  }
+
   parseItems(items) {
     var parseFunction = _.bind(this.parseFunction, this);
 


### PR DESCRIPTION
This is an example of how to update the components so content only has to be preloaded once.  

1.  I added a component to the parent route / called page. 
2.  Page starts a preload of the items. 
3.  I updated Search to ask if the items are already preloaded if they are it sets its state as preloaded otherwise it waits for the event. 
4.  AND MOST IMPORTANT.  To get the router to fire correctly you must use 
import { Link } from 'react-router' 
to link to knew pages as was done in SiteIndex.  


