### PR TITLE
Dec 869 better

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-addons-transition-group": "0.14.6",
     "react-addons-update": "0.14.6",
     "react-dom": "0.14.6",
+    "react-motion": "^0.4.2",
     "react-responsive": "^1.1.0",
     "react-router": "2.0.0",
     "react-scroll": "^0.35.0",

--- a/src/components/Document/Document.jsx
+++ b/src/components/Document/Document.jsx
@@ -57,7 +57,6 @@ Document.propTypes = {
   documentId: React.PropTypes.string.isRequired,
   item: React.PropTypes.object,
   parent: React.PropTypes.object,
-  highlightChildren: React.PropTypes.bool,
 }
 
 Document.defaultProps = {
@@ -66,7 +65,6 @@ Document.defaultProps = {
     maxWidth: "32.5em", // Should put it between 70-75 characters at 1em (16px)
     margin: "0 auto",
   },
-  highlightChildren: false,
 };
 
 export default Document;

--- a/src/components/Document/Document.jsx
+++ b/src/components/Document/Document.jsx
@@ -1,12 +1,13 @@
 'use strict'
 import React, { Component, PropTypes } from 'react';
 
-import ItemStore from '../../store/ItemStore.js'
-import Paragraph from './Paragraph.jsx'
-import Title from './Title.jsx'
-import DownloadPDF from './DownloadPDF.jsx'
-import CurrentParagraph from './CurrentParagraph.jsx'
-import CopyrightNotification from './CopyrightNotification.jsx'
+import ItemStore from '../../store/ItemStore.js';
+import Paragraph from './Paragraph.jsx';
+import Title from './Title.jsx';
+import DownloadPDF from './DownloadPDF.jsx';
+import CurrentParagraph from './CurrentParagraph.jsx';
+import CopyrightNotification from './CopyrightNotification.jsx';
+import CompareStore from '../../store/CompareStore.js';
 
 class Document extends Component {
   constructor(props) {
@@ -24,7 +25,15 @@ class Document extends Component {
   }
 
   paragraph(item) {
-    return (<Paragraph key={ item.id } item={ item } selectedItem={ this._item }/>);
+    let selectedItem = null;
+    if(this._parent == this._item) {
+      if(CompareStore.itemInCompare(item)) {
+        selectedItem = item;
+      }
+    } else {
+      selectedItem = this._item;
+    }
+    return (<Paragraph key={ item.id } item={ item } selectedItem={ selectedItem }/>);
   }
 
   render() {
@@ -48,6 +57,7 @@ Document.propTypes = {
   documentId: React.PropTypes.string.isRequired,
   item: React.PropTypes.object,
   parent: React.PropTypes.object,
+  highlightChildren: React.PropTypes.bool,
 }
 
 Document.defaultProps = {
@@ -55,7 +65,8 @@ Document.defaultProps = {
     fontSize: "16px",
     maxWidth: "32.5em", // Should put it between 70-75 characters at 1em (16px)
     margin: "0 auto",
-  }
+  },
+  highlightChildren: false,
 };
 
 export default Document;

--- a/src/components/Document/Document.jsx
+++ b/src/components/Document/Document.jsx
@@ -8,6 +8,7 @@ import DownloadPDF from './DownloadPDF.jsx';
 import CurrentParagraph from './CurrentParagraph.jsx';
 import CopyrightNotification from './CopyrightNotification.jsx';
 import CompareStore from '../../store/CompareStore.js';
+import ParagraphJumpList from './ParagraphJumpList.jsx';
 
 class Document extends Component {
   constructor(props) {
@@ -18,6 +19,10 @@ class Document extends Component {
       // If the item has no parents, we assume it is a parent.
       this._parent = this._item;
     }
+    this.state = {
+      selectedParagraph: null,
+    }
+    this.selectParagraph = this.selectParagraph.bind(this);
   }
 
   paragraphs() {
@@ -26,7 +31,9 @@ class Document extends Component {
 
   paragraph(item) {
     let selectedItem = null;
+    // if we're looking at a whole document
     if(this._parent == this._item) {
+      // check to see if current paragraph is in the store
       if(CompareStore.itemInCompare(item)) {
         selectedItem = item;
       }
@@ -36,6 +43,11 @@ class Document extends Component {
     return (<Paragraph key={ item.id } item={ item } selectedItem={ selectedItem }/>);
   }
 
+  selectParagraph(value) {
+    console.log(value);
+    this.setState({selectedParagraph: value});
+  }
+
   render() {
     return (
       <div className="document">
@@ -43,6 +55,11 @@ class Document extends Component {
           { this.props.children }
         </div>
         <Title item={this._parent} />
+
+        <ParagraphJumpList
+          paragraphs={ this.paragraphs() }
+          primaryAction={ this.selectParagraph }
+        />
         <CopyrightNotification item={ this._parent } />
         <hr />
         <div style={ this.props.bodyStyle } >

--- a/src/components/Document/DocumentListItem.jsx
+++ b/src/components/Document/DocumentListItem.jsx
@@ -8,7 +8,7 @@ class DocumentListItem extends Component {
     super(props);
 
     this.primaryAction = this.primaryAction.bind(this);
-    this.paragraphs = this.paragraphs.bind(this);
+    // this.paragraphs = this.paragraphs.bind(this);
 
     this._item = this.props.item;
     this._subItems = this.props.subItems;
@@ -19,28 +19,25 @@ class DocumentListItem extends Component {
     event.preventDefault();
   }
 
-  paragraphs() {
-    let clickFunc = this.props.primaryAction;
-    let paragraphs = [];
-      this.props.subItems.forEach(function(item, index){
-        paragraphs.push(
-          <DocumentParagraphListItem
-            key={item.id}
-            item={item}
-            primaryAction={clickFunc}
-          />
-        );
-    });
-    return paragraphs;
-  }
+  // paragraphs() {
+  //   let clickFunc = this.props.primaryAction;
+  //   let paragraphs = [];
+  //     this.props.subItems.forEach(function(item, index){
+  //       paragraphs.push(
+  //         <DocumentParagraphListItem
+  //           key={item.id}
+  //           item={item}
+  //           primaryAction={clickFunc}
+  //         />
+  //       );
+  //   });
+  //   return paragraphs;
+  // }
 
   render() {
     return (
       <li style={{margin: "5px"}} >
         <div style={{cursor: 'pointer'}} onClick={this.primaryAction} >{this._item.name}</div>
-        <ul>
-          {this.paragraphs()}
-        </ul>
       </li>
     );
   }

--- a/src/components/Document/ParagraphJumpList.jsx
+++ b/src/components/Document/ParagraphJumpList.jsx
@@ -1,0 +1,46 @@
+'use strict'
+import React, { Component, PropTypes } from 'react';
+import ItemStore from '../../store/ItemStore.js';
+
+class ParagraphJumpList extends Component {
+  constructor(props) {
+    super(props);
+    this.list = this.list.bind(this);
+    this.itemSelect = this.itemSelect.bind(this);
+  }
+
+  itemSelect(e) {
+    this.props.primaryAction(e.target.value);
+  }
+
+  list() {
+    let listOptions = []
+    for(var i = 0; i < this.props.paragraphs.length; i++) {
+      listOptions.push(
+        <option
+          key={ this.props.paragraphs[i].key }
+          value={ this.props.paragraphs[i].key }
+        >{ ItemStore.getItem(this.props.paragraphs[i].key).name }
+      </option>
+      );
+    }
+    return (
+      <select onChange={this.itemSelect}>{listOptions}</select>)
+    ;
+  }
+
+  render() {
+    return (
+      <div style={{float:'right'}}>
+        {this.list()}
+      </div>
+    )
+  }
+}
+
+ParagraphJumpList.propTypes = {
+  paragraphs: React.PropTypes.array,
+  primaryAction: React.PropTypes.func,
+}
+
+export default ParagraphJumpList;

--- a/src/components/Notebook/NotebookDocument.jsx
+++ b/src/components/Notebook/NotebookDocument.jsx
@@ -38,7 +38,6 @@ class NotebookDocument extends Component {
         <Document
           documentId={ this.props.document.id }
           bodyStyle={ this.documentBodyStyle() }
-          highlightChildren={true}
         >
           <a href="#" className="remove-document" onClick={ this.removeClick.bind(this) }>
             <mui.FontIcon className="material-icons">clear</mui.FontIcon>

--- a/src/components/Notebook/NotebookDocument.jsx
+++ b/src/components/Notebook/NotebookDocument.jsx
@@ -35,7 +35,11 @@ class NotebookDocument extends Component {
     return (
       <div>
         <Heading title={ this.documentTitle() } />
-        <Document documentId={ this.props.document.id } bodyStyle={ this.documentBodyStyle() }>
+        <Document
+          documentId={ this.props.document.id }
+          bodyStyle={ this.documentBodyStyle() }
+          highlightChildren={true}
+        >
           <a href="#" className="remove-document" onClick={ this.removeClick.bind(this) }>
             <mui.FontIcon className="material-icons">clear</mui.FontIcon>
           </a>

--- a/src/components/Notebook/NotebookDocument.jsx
+++ b/src/components/Notebook/NotebookDocument.jsx
@@ -25,7 +25,7 @@ class NotebookDocument extends Component {
   documentBodyStyle() {
     return {
       overflowY: "auto",
-      height: "400px",
+      height: "226px",
       clear: "both",
       marginBottom: '1em',
     };


### PR DESCRIPTION
Work in progress:

Highlights all selected paragraphs within document.
Placeholder version of jumplist (currently returning all paragraphs, will filter to selected paragraphs in next iteration).
Jumplist does not do any visible action, but it is setting the state on the document for the currently selected paragraph.
Next step is to get the independent scrolling sorted before enabling the jumplist to scroll to selected paragraph.