### PR TITLE
DEC-890: Speed up search components

### DIFF
--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -26,7 +26,6 @@ var Search = React.createClass({
 
   getInitialState: function() {
     return ({items: [],})
-
   },
 
   searchStoreChanged: function(reason) {
@@ -57,18 +56,18 @@ var Search = React.createClass({
   },
 
   componentWillMount: function() {
-    if ('object' == typeof(this.props.collection)) {
-      this.setValues(this.props.collection);
-    } else {
-      this.loadSearchItems(this.props.collection);
-    }
+    this.loadSearchItems(this.props.collection, this.props.searchTerm);
   },
 
-  loadSearchItems: function(collection) {
+  componentWillReceiveProps: function(nextProps) {
+    this.loadSearchItems(nextProps.collection, nextProps.searchTerm);
+  },
+
+  loadSearchItems: function(collection, searchTerm) {
     $.ajax({
       context: this,
       type: "GET",
-      url:  collection + '/search?q=' + this.props.searchTerm + '&rows=100',
+      url:  collection + '/search?q=' + searchTerm + '&rows=100',
       dataType: "json",
       success: function(result) {
         this.setItems(result.hits);
@@ -105,7 +104,6 @@ var Search = React.createClass({
         <Heading title={this.props.title} />
         <SearchDisplayList items={this.state.items}/>
       </div>
-
     );
   }
 });

--- a/src/components/Search/SearchBox.jsx
+++ b/src/components/Search/SearchBox.jsx
@@ -1,29 +1,31 @@
 'use strict'
 var React = require('react');
 var mui = require('material-ui');
-var SearchStore = require('../../store/SearchStore.js');
 var SearchActions = require('../../actions/SearchActions.js');
 var VaticanID = require('../../constants/VaticanID.js');
 var HumanRightsID = require('../../constants/HumanRightsID.js');
 
 var SearchBox = React.createClass({
+  contextTypes: {
+    router: React.PropTypes.object.isRequired
+  },
+
+  getInitialState: function() {
+    return {
+      searchTerm: decodeURIComponent(window.location.search.split(',')[0].replace('?q=', ''))
+    };
+  },
+
   onChange: function(e) {
     this.setTerm(e.target.value);
   },
 
   onClick: function(e) {
-    var url = window.location.origin
-      + "/search?q=" + this.state.searchTerm;
-    window.location = url;
-  },
-
-  componentDidMount: function() {
-    this.setTerm(SearchStore.searchTerm);
+    this.context.router.push("/search?q=" + encodeURIComponent(this.state.searchTerm));
   },
 
   setTerm: function(term) {
-    var cleanTerm = encodeURIComponent(term);
-    this.setState({searchTerm: cleanTerm});
+    this.setState({ searchTerm: term });
   },
 
   inputStyle: function() {
@@ -40,15 +42,12 @@ var SearchBox = React.createClass({
   },
 
   input: function() {
-    var defaultValue = '';
-    if(window.location.search) {
-      defaultValue = window.location.search.split(',')[0].replace('?q=', '')
-    }
+
     return (<input
       placeholder='SEARCH THE DATABASE'
       ref='searchBox'
       onChange={this.onChange}
-      defaultValue={defaultValue}
+      defaultValue={this.state.searchTerm}
       onKeyDown={this.handleKeyDown}
       inputStyle={this.inputStyle()}
       style={{

--- a/src/components/Search/TopicFacet.jsx
+++ b/src/components/Search/TopicFacet.jsx
@@ -2,6 +2,7 @@
 import React, { Component, PropTypes } from 'react';
 import TopicFacets from './TopicFacets.jsx';
 import ChildValue from './ChildValue.js';
+import QueryParm from '../../modules/QueryParam.js';
 import { Link } from 'react-router'
 
 class TopicFacet extends Component {
@@ -21,7 +22,8 @@ class TopicFacet extends Component {
   }
 
   getLinkPath() {
-    return '/search' + '?q=' + ChildValue(this.props.topic);
+    var currentSearch = QueryParm('q').split(',');
+    return '/search?q=' + currentSearch[0] + ',' + ChildValue(this.props.topic);
   }
 
   arrowStyle() {

--- a/src/components/Search/TopicFacet.jsx
+++ b/src/components/Search/TopicFacet.jsx
@@ -2,6 +2,7 @@
 import React, { Component, PropTypes } from 'react';
 import TopicFacets from './TopicFacets.jsx';
 import ChildValue from './ChildValue.js';
+import { Link } from 'react-router'
 
 class TopicFacet extends Component {
   constructor(props) {
@@ -13,16 +14,14 @@ class TopicFacet extends Component {
       selected: searchStr.search(this.props.topic.value) > -1,
     }
     this.onArrowClick = this.onArrowClick.bind(this);
-    this.onLabelClick = this.onLabelClick.bind(this);
   }
 
   onArrowClick() {
     this.setState({expanded: !this.state.expanded});
   }
 
-  onLabelClick() {
-    let currentSearch = window.location.search.split(',');
-    window.location.search = currentSearch[0] + ',' + ChildValue(this.props.topic);
+  getLinkPath() {
+    return '/search' + '?q=' + ChildValue(this.props.topic);
   }
 
   arrowStyle() {
@@ -40,7 +39,6 @@ class TopicFacet extends Component {
     let arrow = (<div style={{display: 'inline-block', width: '20px'}} />);
     if(this.props.topic){
       if(this.props.topic.children) {
-
         arrow = (
           <i
             className="material-icons"
@@ -51,19 +49,12 @@ class TopicFacet extends Component {
         if(this.state.expanded) {
           children = (<TopicFacets source={this.props.topic.children} />);
         }
-
       }
       return (
         <li>
           <div>
             {arrow}
-            <span
-              onClick={this.onLabelClick}
-              style={{
-                cursor: 'pointer',
-                fontWeight: this.state.selected ? 'bold': 'normal',
-              }}
-            >{this.props.topic.name}</span>
+            <Link to={ this.getLinkPath() }>{this.props.topic.name}</Link>
           </div>
           <ul style={{
               listStyleType: 'none',


### PR DESCRIPTION
Why: Search box and topics are causing a reload of the entire page, which forces it to reload all items and search hits (slow).
How: Changed the sub components of SearchPage (Search, TopicFacet, and SearchBox) to work with React router instead of changing window locations. 