### PR TITLE
DEC-892 Initial script to cache vatican data

### DIFF
--- a/awsbuild.sh
+++ b/awsbuild.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 PROJECT=csthr
 BUCKET=${PROJECT}.library.nd.edu
+ENV_ALIAS=honeycombpprd-vm
 
-cd ./public
+cd ./public/cache_data
+
+curl -o cst_data.json https://${ENV_ALIAS}.library.nd.edu/v1/collections/vatican/items
+curl -o ihrl_data.json https://${ENV_ALIAS}library.nd.edu/v1/collections/humanrights/items
 
 aws s3 mb s3://${BUCKET}
 aws s3 website s3://${BUCKET} --index-document index.html --error-document index.html
-aws s3 sync . s3://${BUCKET} --exclude '.*' --exclude '*.md' --exclude '*.json' --delete --acl public-read
+aws s3 sync . s3://${BUCKET} --exclude '.*' --exclude '*.md' --delete --acl public-read
 
 echo ${BUCKET}.s3-website-us-east-1.amazonaws.com

--- a/awsbuild.sh
+++ b/awsbuild.sh
@@ -3,10 +3,10 @@ PROJECT=csthr
 BUCKET=${PROJECT}.library.nd.edu
 ENV_ALIAS=honeycombpprd-vm
 
-cd ./public/cache_data
+cd ./public
 
-curl -o cst_data.json https://${ENV_ALIAS}.library.nd.edu/v1/collections/vatican/items
-curl -o ihrl_data.json https://${ENV_ALIAS}library.nd.edu/v1/collections/humanrights/items
+curl -o ./cache_data/cst_data.json https://${ENV_ALIAS}.library.nd.edu/v1/collections/vatican/items
+curl -o ./cache_data/ihrl_data.json https://${ENV_ALIAS}library.nd.edu/v1/collections/humanrights/items
 
 aws s3 mb s3://${BUCKET}
 aws s3 website s3://${BUCKET} --index-document index.html --error-document index.html


### PR DESCRIPTION
What: Created script that grabs the collection data from the CST and IHRL collections and deposits those files into the S3 bucket for consumption.
Why: In order to speed up the initial load process for the search interface of the CCHR research database.