### PR TITLE
Fix edge case where no documents are listed because only titles are found.

### DIFF
--- a/src/components/Search/SearchDisplayList.jsx
+++ b/src/components/Search/SearchDisplayList.jsx
@@ -50,11 +50,14 @@ var SearchDisplayList = React.createClass({
         );
       }
 
+
+    }
+    if(groupedItems.length > 0) {
       return (
         <div className="search-list">
           {itemNodes}
         </div>
-      )
+      );
     }
     return (
       <div


### PR DESCRIPTION
Fix the way items are filtered out of the text.  Now if you filter all the nodes because they are not BodyText it will return nothing 