### PR TITLE
DEC-886 Fix localStorage in CompareStore

### DIFF
--- a/src/components/Document/AddToCompare.jsx
+++ b/src/components/Document/AddToCompare.jsx
@@ -19,7 +19,6 @@ class AddToCompare extends Component {
   }
 
   componentWillMount() {
-    require('events').EventEmitter.defaultMaxListeners = 100000;
     CompareStore.on('ItemCompareUpdated', this.setStateFromCompareStore);
   }
 

--- a/src/components/Document/AddToCompare.jsx
+++ b/src/components/Document/AddToCompare.jsx
@@ -19,6 +19,7 @@ class AddToCompare extends Component {
   }
 
   componentWillMount() {
+    require('events').EventEmitter.defaultMaxListeners = 100000;
     CompareStore.on('ItemCompareUpdated', this.setStateFromCompareStore);
   }
 

--- a/src/components/Notebook/NotebookLink.jsx
+++ b/src/components/Notebook/NotebookLink.jsx
@@ -9,18 +9,8 @@ class NotebookLink extends Component {
   clickAction() {
     CompareStore.clearColumnItems();
     if(!this.props.disabled) {
-      let vaticanItems = [];
-      let humanRightItems = [];
-      if(window.localStorage.length > 0) {
-        for(var i = 0; i < window.localStorage.length; i++) {
-          if(window.localStorage.getItem(window.localStorage.key(i)) === VaticanID) {
-            vaticanItems.push(window.localStorage.key(i));
-          }
-          else if (window.localStorage.getItem(window.localStorage.key(i)) === HumanRightsID) {
-            humanRightItems.push(window.localStorage.key(i));
-          }
-        }
-      }
+      let vaticanItems = CompareStore.collectionItems(VaticanID);
+      let humanRightItems = CompareStore.collectionItems(HumanRightsID);
 
       let vString = 'v=' + vaticanItems.join('|');
       let hString = 'h=' + humanRightItems.join('|');

--- a/src/components/Search/Drawer.jsx
+++ b/src/components/Search/Drawer.jsx
@@ -35,15 +35,17 @@ class Drawer extends Component {
     let parentsVat = [];
     let parentsHu = [];
     for (var i = 0; i < compareItems.length; i++) {
-      let parent = ItemStore.getItemParent(ItemStore.getItem(compareItems[i]));
-      if(parent.collection_id === VaticanID) {
-        if(parentsVat.indexOf(parent) < 0) {
-          parentsVat.push(parent);
+      if(ItemStore.getItem(compareItems[i])) {
+        let parent = ItemStore.getItemParent(ItemStore.getItem(compareItems[i]));
+        if(parent.collection_id === VaticanID) {
+          if(parentsVat.indexOf(parent) < 0) {
+            parentsVat.push(parent);
+          }
         }
-      }
-      if(parent.collection_id === HumanRightsID) {
-        if(parentsHu.indexOf(parent) < 0) {
-          parentsHu.push(parent);
+        if(parent.collection_id === HumanRightsID) {
+          if(parentsHu.indexOf(parent) < 0) {
+            parentsHu.push(parent);
+          }
         }
       }
     }

--- a/src/modules/LocalStorageExpiration.js
+++ b/src/modules/LocalStorageExpiration.js
@@ -1,0 +1,7 @@
+module.exports = function() {
+  // clear localStorage if the is no previousVisit Time or visitTime > 1 day
+  if(!localStorage.getItem('visitTime') || localStorage.getItem('visitTime') <  new Date(Date.now - 24*60*60000)) {
+    localStorage.clear();
+  }
+  localStorage.setItem('visitTime', Date.now());
+}

--- a/src/modules/LocalStorageExpiration.js
+++ b/src/modules/LocalStorageExpiration.js
@@ -1,17 +1,17 @@
 import VaticanID from '../constants/VaticanID.js';
 import HumanRightsID from '../constants/HumanRightsID.js';
 module.exports = function(force) {
-  if(!force) {
+  if(force == null) {
     force = false;
   }
   // clear localStorage if the is no previousVisit Time or visitTime > 1 day
-  if(!localStorage.getItem('visitTime') || localStorage.getItem('visitTime' || force) <  new Date(Date.now - 24*60*60000)) {
+  if(force || !localStorage.getItem('visitTime')) {
     localStorage.clear();
   }
-  if(!localStorage.getItem(VaticanID) || force) {
+  if(force || !localStorage.getItem(VaticanID)) {
     localStorage.setItem(VaticanID, '{}')
   }
-  if(!localStorage.getItem(HumanRightsID) || force) {
+  if(force || !localStorage.getItem(HumanRightsID)) {
     localStorage.setItem(HumanRightsID, '{}');
   }
   localStorage.setItem('visitTime', Date.now());

--- a/src/modules/LocalStorageExpiration.js
+++ b/src/modules/LocalStorageExpiration.js
@@ -1,7 +1,18 @@
-module.exports = function() {
+import VaticanID from '../constants/VaticanID.js';
+import HumanRightsID from '../constants/HumanRightsID.js';
+module.exports = function(force) {
+  if(!force) {
+    force = false;
+  }
   // clear localStorage if the is no previousVisit Time or visitTime > 1 day
-  if(!localStorage.getItem('visitTime') || localStorage.getItem('visitTime') <  new Date(Date.now - 24*60*60000)) {
+  if(!localStorage.getItem('visitTime') || localStorage.getItem('visitTime' || force) <  new Date(Date.now - 24*60*60000)) {
     localStorage.clear();
+  }
+  if(!localStorage.getItem(VaticanID) || force) {
+    localStorage.setItem(VaticanID, '{}')
+  }
+  if(!localStorage.getItem(HumanRightsID) || force) {
+    localStorage.setItem(HumanRightsID, '{}');
   }
   localStorage.setItem('visitTime', Date.now());
 }

--- a/src/routes/SearchPage.jsx
+++ b/src/routes/SearchPage.jsx
@@ -5,6 +5,8 @@ import Colors from 'material-ui/lib/styles/colors';
 import Search from '../components/Search/Search.jsx';
 import SearchActions from '../actions/SearchActions.js';
 import SearchStore from '../store/SearchStore.js';
+import CompareStore from '../store/CompareStore.js';
+import QueryParm from '../modules/QueryParam.js';
 import FacetQueryParms from '../modules/FacetQueryParams.js';
 import HoneycombURL from '../modules/HoneycombURL.js';
 import VaticanID from '../constants/VaticanID.js';
@@ -63,6 +65,7 @@ class SearchPage extends Component {
 
   preLoadFinished() {
     this.setState({loaded: true});
+    CompareStore.verifyStore();
   }
 
   renderSearchBody() {

--- a/src/store/CompareStore.js
+++ b/src/store/CompareStore.js
@@ -9,11 +9,12 @@
 var AppDispatcher = require("../dispatcher/AppDispatcher.jsx");
 var EventEmitter = require("events").EventEmitter;
 var CompareActionTypes = require("../constants/CompareActionTypes.jsx");
+import LocalStorageExpiration from '../modules/LocalStorageExpiration.js';
 
 class CompareStore extends EventEmitter {
   constructor() {
     super();
-
+    LocalStorageExpiration();
     this._column1Item = false;
     this._column2Item = false;
     this._forceDrawerState = false ;
@@ -63,8 +64,11 @@ class CompareStore extends EventEmitter {
   allItems() {
     let items = [];
     for(var i = 0; i < window.localStorage.length; i++) {
-      items.push(window.localStorage.key(i));
+      if( window.localStorage.key(i) != 'visitTime') {
+        items.push(window.localStorage.key(i));
+      }
     }
+
 
     return items;
   }

--- a/src/store/CompareStore.js
+++ b/src/store/CompareStore.js
@@ -31,11 +31,11 @@ class CompareStore extends EventEmitter {
   }
 
   verifyStore() {
-    // if store is invalid clear everything in the CompareStore and reload page
     if(!this.validStore()) {
       console.log('Invalid collection item found.');
-      this.clearAll();
-      window.location.reload();
+      LocalStorageExpiration(true);
+      this.resetDrawer();
+      this.emit("ItemCompareUpdated");
     }
   }
 

--- a/src/store/CompareStore.js
+++ b/src/store/CompareStore.js
@@ -114,25 +114,21 @@ class CompareStore extends EventEmitter {
     this.emit("ItemCompareUpdated");
   }
 
-  allItems() {
-    var vaticanItems = [];
-    if(window.localStorage.getItem(VaticanID)) {
-      var vaticanObject = JSON.parse(window.localStorage.getItem(VaticanID));
-      if(vaticanObject.items) {
-        vaticanItems = vaticanObject.items;
+  collectionItems(collection_id) {
+    var items = [];
+    if(window.localStorage.getItem(collection_id)) {
+      var obj = JSON.parse(window.localStorage.getItem(collection_id));
+      if(obj.items) {
+        items = obj.items;
       }
     }
-
-    var humanRightsItems = [];
-    if(window.localStorage.getItem(HumanRightsID)) {
-      var humanRightsObject = JSON.parse(window.localStorage.getItem(HumanRightsID));
-      if(humanRightsObject.items) {
-        humanRightsItems = humanRightsObject.items;
-      }
-    }
-
-    var items = vaticanItems.concat(humanRightsItems);
     return items;
+  }
+
+  allItems() {
+    var vaticanItems = this.collectionItems(VaticanID);
+    var humanRightsItems = this.collectionItems(HumanRightsID);
+    return vaticanItems.concat(humanRightsItems);
   }
 
   itemInCompare(item) {

--- a/src/store/CompareStore.js
+++ b/src/store/CompareStore.js
@@ -24,6 +24,7 @@ class CompareStore extends EventEmitter {
 
   // Receives actions sent by the AppDispatcher
   receiveAction(action) {
+    LocalStorageExpiration();
     switch(action.actionType) {
       case CompareActionTypes.ADD_ITEM_TO_COMPARE:
         this.setItem(action.item);

--- a/src/store/ItemStore.js
+++ b/src/store/ItemStore.js
@@ -10,7 +10,6 @@ var AppDispatcher = require("../dispatcher/AppDispatcher.jsx");
 var EventEmitter = require("events").EventEmitter;
 var ItemActionTypes = require("../constants/ItemActionTypes.jsx");
 var _ = require("underscore");
-import LocalStorageExpiration from '../modules/LocalStorageExpiration.js';
 
 class ItemStore extends EventEmitter {
   constructor() {

--- a/src/store/ItemStore.js
+++ b/src/store/ItemStore.js
@@ -10,6 +10,7 @@ var AppDispatcher = require("../dispatcher/AppDispatcher.jsx");
 var EventEmitter = require("events").EventEmitter;
 var ItemActionTypes = require("../constants/ItemActionTypes.jsx");
 var _ = require("underscore");
+import LocalStorageExpiration from '../modules/LocalStorageExpiration.js';
 
 class ItemStore extends EventEmitter {
   constructor() {
@@ -21,6 +22,7 @@ class ItemStore extends EventEmitter {
     this._vatican_finished = false;
     this._human_rights_finished = false;
     AppDispatcher.register(this.receiveAction.bind(this));
+    this.validItem = this.validItem.bind(this);
   }
 
   // Receives actions sent by the AppDispatcher
@@ -57,10 +59,6 @@ class ItemStore extends EventEmitter {
 
   parseFunction(item) {
     this._items[item.id] = item;
-    if(!item) {
-      localStorage.clear();
-      location.reload();
-    }
     this._user_defined2_item_id[item.user_defined_id] = item.id;
     if (item.metadata.parent_id) {
       var parent_id = item.metadata.parent_id.values[0].value;
@@ -71,6 +69,13 @@ class ItemStore extends EventEmitter {
     } else {
       this._parentItems.push(item);
     }
+  }
+
+  validItem(id) {
+    if(this.getItem(id)) {
+      return true;
+    }
+    else return false;
   }
 
   getItem(id) {

--- a/src/store/ItemStore.js
+++ b/src/store/ItemStore.js
@@ -57,6 +57,10 @@ class ItemStore extends EventEmitter {
 
   parseFunction(item) {
     this._items[item.id] = item;
+    if(!item) {
+      localStorage.clear();
+      location.reload();
+    }
     this._user_defined2_item_id[item.user_defined_id] = item.id;
     if (item.metadata.parent_id) {
       var parent_id = item.metadata.parent_id.values[0].value;


### PR DESCRIPTION
 * Rewrite Compare store to store vatican and human rights items separately in stringifyed-arrays.
 * Fix drawer check on page load.
 * Add a force option to expire localStorage.
 * Add an item verification check and use force option on localStorageExpire if an invalid item is found.