### PR TITLE
clear columns before going to the compare page

### DIFF
--- a/src/actions/CompareActions.js
+++ b/src/actions/CompareActions.js
@@ -31,6 +31,12 @@ class CompareActions {
       item: item
     });
   }
+
+  clearColumns() {
+    AppDispatcher.dispatch({
+      actionType: CompareActionTypes.CLEAR_COLUMNS,
+    });
+  }
 }
 
 module.exports = new CompareActions();

--- a/src/components/Notebook/NotebookLink.jsx
+++ b/src/components/Notebook/NotebookLink.jsx
@@ -2,10 +2,12 @@
 import React, { Component, PropTypes } from 'react';
 import VaticanID from '../../constants/VaticanID.js';
 import HumanRightsID from '../../constants/HumanRightsID.js';
+import CompareStore from '../../store/CompareStore.js';
 
 class NotebookLink extends Component {
 
   clickAction() {
+    CompareStore.clearColumnItems();
     if(!this.props.disabled) {
       let vaticanItems = [];
       let humanRightItems = [];

--- a/src/constants/CompareActionTypes.jsx
+++ b/src/constants/CompareActionTypes.jsx
@@ -5,6 +5,7 @@ var CompareActionTypes = keyMirror({
   REMOVE_ITEM_FROM_COMPARE: false,
   SET_COMPARE_COLUMN_ITEM: false,
   REMOVE_COMPARE_COLUMN_ITEM: false,
+  CLEAR_COLUMNS: false,
 });
 
 module.exports = CompareActionTypes;

--- a/src/store/CompareStore.js
+++ b/src/store/CompareStore.js
@@ -36,6 +36,9 @@ class CompareStore extends EventEmitter {
       case CompareActionTypes.REMOVE_COMPARE_COLUMN_ITEM:
         this.removeColumnItem(action.item);
         break;
+      case CompareActionTypes.CLEAR_COLUMNS:
+        this.clearColumnItems();
+        break;
     }
   }
 
@@ -111,6 +114,12 @@ class CompareStore extends EventEmitter {
     } else if (this._column2Item == item) {
       this._column2Item = false;
     }
+    this.emit("CompareColumnsUpdated");
+  }
+
+  clearColumnItems() {
+    this._column1Item = false;
+    this._column2Item = false;
     this.emit("CompareColumnsUpdated");
   }
 


### PR DESCRIPTION
Create clear columns action to clear both columns.
Use the action when clicking the link to the notebook to clear columns so old loaded data does not persist.