### PR TITLE
DEC-896: Search list feedback

### DIFF
--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -52,7 +52,7 @@ var Search = React.createClass({
         items.push(item);
       }
     }
-    this.setState({items: items,});
+    this.setState({ loading: false, items: items,});
   },
 
   componentWillMount: function() {
@@ -64,12 +64,14 @@ var Search = React.createClass({
   },
 
   loadSearchItems: function(collection, searchTerm) {
+    this.setState({ loading: true });
     $.ajax({
       context: this,
       type: "GET",
       url:  collection + '/search?q=' + searchTerm + '&rows=10000',
       dataType: "json",
       success: function(result) {
+        this.setState({ loading: false });
         this.setItems(result.hits);
       },
       error: function(request, status, thrownError) {
@@ -102,7 +104,8 @@ var Search = React.createClass({
     return (
       <div>
         <Heading title={this.props.title} />
-        <SearchDisplayList items={this.state.items}/>
+        { this.state.loading && <div>Loading...</div> }
+        { !this.state.loading && <SearchDisplayList items={this.state.items}/> }
       </div>
     );
   }

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -1,10 +1,16 @@
 'use strict'
 var React = require('react');
+var CircularProgress = require('material-ui/lib/circular-progress');
+var Colors = require('material-ui/lib/styles/colors');
 var PageContent = require('../../layout/PageContent.jsx');
 var SearchStore = require('../../store/SearchStore.js');
 var SearchActions = require('../../actions/SearchActions.js');
 var SearchDisplayList = require('./SearchDisplayList.jsx');
 var Heading = require('../Shared/Heading.jsx');
+
+const styles = {
+  circleProgress: { margin: "0px 0 0 -25px", left: "50%" }
+};
 
 var Search = React.createClass({
 
@@ -71,7 +77,6 @@ var Search = React.createClass({
       url:  collection + '/search?q=' + searchTerm + '&rows=10000',
       dataType: "json",
       success: function(result) {
-        this.setState({ loading: false });
         this.setItems(result.hits);
       },
       error: function(request, status, thrownError) {
@@ -104,7 +109,7 @@ var Search = React.createClass({
     return (
       <div>
         <Heading title={this.props.title} />
-        { this.state.loading && <div>Loading...</div> }
+        { this.state.loading && <CircularProgress style={ styles.circleProgress } color={ Colors.blueGrey700 }/> }
         { !this.state.loading && <SearchDisplayList items={this.state.items}/> }
       </div>
     );

--- a/src/routes/SearchPage.jsx
+++ b/src/routes/SearchPage.jsx
@@ -1,6 +1,6 @@
 'use strict'
 import React, { Component, PropTypes } from 'react';
-import BackgroundIcon from 'material-ui/lib/svg-icons/av/library-books';
+import BackgroundIcon from 'material-ui/lib/svg-icons/action/find-in-page';
 import Colors from 'material-ui/lib/styles/colors';
 import Search from '../components/Search/Search.jsx';
 import QueryParm from '../modules/QueryParam.js';


### PR DESCRIPTION
Why: Elapsed time between changing query to re-render can be very small, depending on the search. This can cause the user to think that nothing happened. A secondary issue is that, in some cases, the results don't actually change when clicking on different topics.
How: Changed Search component to render a progress indicator any time a new search is initiated. This seems to correct both problems now that it is essentially removing the SearchDisplayList in each column from the virtual dom while waiting on search results. If we continue to have issues, we might have to dig further down into the children of Search and make sure they are all appropriately reinitializing local state data when the router re-renders the components. Also, changed the icon on the empty search to be something more indicative of searching. 