### PR TITLE
DEC-895: Multiselect topics

### DIFF
--- a/src/actions/SearchActions.js
+++ b/src/actions/SearchActions.js
@@ -2,17 +2,17 @@
 var AppDispatcher = require("../dispatcher/AppDispatcher.jsx");
 var SearchActionTypes = require("../constants/SearchActionTypes.jsx");
 class SearchActions {
-  addTopic(topic) {
+  addTopics(topics) {
     AppDispatcher.dispatch({
-      actionType: SearchActionTypes.SEARCH_ADD_TOPIC,
-      topic: topic
+      actionType: SearchActionTypes.SEARCH_ADD_TOPICS,
+      topics: topics
     });
   }
 
-  removeTopic(topic) {
+  removeTopics(topics) {
     AppDispatcher.dispatch({
-      actionType: SearchActionTypes.SEARCH_REMOVE_TOPIC,
-      topic: topic
+      actionType: SearchActionTypes.SEARCH_REMOVE_TOPICS,
+      topics: topics
     });
   }
 }

--- a/src/actions/SearchActions.js
+++ b/src/actions/SearchActions.js
@@ -1,56 +1,19 @@
 "use strict"
 var AppDispatcher = require("../dispatcher/AppDispatcher.jsx");
 var SearchActionTypes = require("../constants/SearchActionTypes.jsx");
-
 class SearchActions {
-  // Init
-  loadSearchResults(collection, baseApiUrl, searchTerm, facetOption, sortOption, start, view) {
+  addTopic(topic) {
     AppDispatcher.dispatch({
-      actionType: SearchActionTypes.SEARCH_LOAD_RESULTS,
-      collection: collection,
-      baseApiUrl: baseApiUrl,
-      searchTerm: searchTerm,
-      facetOption: facetOption,
-      sortOption: sortOption,
-      start: start,
-      view: view
+      actionType: SearchActionTypes.SEARCH_ADD_TOPIC,
+      topic: topic
     });
   }
 
-  reloadSearchResults(data) {
+  removeTopic(topic) {
     AppDispatcher.dispatch({
-      actionType: SearchActionTypes.SEARCH_RELOAD_RESULTS,
-      data: data
-    });
-  }
-
-  setSearchTerm(term) {
-    AppDispatcher.dispatch({
-      actionType: SearchActionTypes.SEARCH_SET_TERM,
-      term: term
-    });
-  }
-
-  setSelectedFacet(facet) {
-    AppDispatcher.dispatch({
-      actionType: SearchActionTypes.SEARCH_SET_SELECTED_FACET,
-      facet: facet
-    });
-  }
-
-  setSort(sort) {
-    AppDispatcher.dispatch({
-      actionType: SearchActionTypes.SEARCH_SET_SORT,
-      sort: sort
-    });
-  }
-
-  setView(view) {
-    AppDispatcher.dispatch({
-      actionType: SearchActionTypes.SEARCH_SET_VIEW,
-      view: view
+      actionType: SearchActionTypes.SEARCH_REMOVE_TOPIC,
+      topic: topic
     });
   }
 }
 module.exports = new SearchActions();
-//export default SearchActions;

--- a/src/assets/css/main.scss
+++ b/src/assets/css/main.scss
@@ -3,3 +3,4 @@
 @import './bootstrap.css';
 @import './csthr.scss';
 @import './document.scss';
+@import './topic-nav.scss';

--- a/src/assets/css/topic-nav.scss
+++ b/src/assets/css/topic-nav.scss
@@ -1,0 +1,28 @@
+.topic-checkbox {
+  width: auto;
+  font-size: 18px;
+  vertical-align: text-top;
+  padding-right: 4px;
+}
+
+.topic-expand {
+  cursor: pointer;
+  display: inline-flex;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 23px;
+  text-align: left;
+}
+
+.topic-expand-label {
+  padding-left: 0px;
+  padding-right: 0px;
+  display: inline-flex;
+}
+
+.topic-arrow {
+  vertical-align: middle;
+  font-size: 20px;
+  color: #224048;
+  cursor: pointer;
+}

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -34,12 +34,6 @@ var Search = React.createClass({
     return ({items: [],})
   },
 
-  searchStoreChanged: function(reason) {
-    this.setState({
-      readyToRender: true,
-    });
-  },
-
   // Callback from LoadRemoteMixin when remote collection is loaded
   setValues: function(collection) {
     if(collection && collection.hits){
@@ -62,26 +56,39 @@ var Search = React.createClass({
   },
 
   componentWillMount: function() {
-    SearchStore.on("SearchStoreChanged", this.loadSearchItems);
-    this.loadSearchItems();
+    this.loadSearchItems(this.props.collection, this.props.searchTerm);
   },
 
   componentWillReceiveProps: function(nextProps) {
     this.loadSearchItems(nextProps.collection, nextProps.searchTerm);
   },
 
+
+  // Using logical operators
+  buildQuery: function(searchTerm) {
+    var qualifiedTopics = SearchStore.topics.map(function(v,i) { return '"' + v +'"' });
+    var unionTopics = qualifiedTopics.join(" OR ");
+    var q = "(" + unionTopics + ")";
+    if(searchTerm != "") {
+      q += " AND \"" + searchTerm + '"';
+    }
+    return encodeURIComponent(q);
+  },
+
+/*
+  // Using comma delimited
+  buildQuery: function(searchTerm) {
+    var q = searchTerm + ',' + SearchStore.topics.join();
+    return encodeURIComponent(q);
+  },
+*/
+
   loadSearchItems: function(collection, searchTerm) {
-    if(collection == undefined) {
-      collection = this.props.collection;
-    }
-    if(searchTerm == undefined) {
-      searchTerm = this.props.searchTerm;
-    }
     this.setState({ loading: true });
     $.ajax({
       context: this,
       type: "GET",
-      url:  collection + '/search?q=' + searchTerm + '&rows=10000',
+      url:  collection + '/search?q=' + this.buildQuery(searchTerm) + '&rows=10000',
       dataType: "json",
       success: function(result) {
         this.setItems(result.hits);

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -56,7 +56,8 @@ var Search = React.createClass({
   },
 
   componentWillMount: function() {
-    this.loadSearchItems(this.props.collection, this.props.searchTerm);
+    SearchStore.on("SearchStoreChanged", this.loadSearchItems);
+    this.loadSearchItems();
   },
 
   componentWillReceiveProps: function(nextProps) {
@@ -64,6 +65,12 @@ var Search = React.createClass({
   },
 
   loadSearchItems: function(collection, searchTerm) {
+    if(collection == undefined) {
+      collection = this.props.collection;
+    }
+    if(searchTerm == undefined) {
+      searchTerm = this.props.searchTerm;
+    }
     $.ajax({
       context: this,
       type: "GET",
@@ -71,7 +78,7 @@ var Search = React.createClass({
       dataType: "json",
       success: function(result) {
         this.setItems(result.hits);
-      },
+      }.bind(this),
       error: function(request, status, thrownError) {
         console.log(thrownError);
       }

--- a/src/components/Search/TopicFacet.jsx
+++ b/src/components/Search/TopicFacet.jsx
@@ -1,6 +1,7 @@
 'use strict'
 import React, { Component, PropTypes } from 'react';
 import Checkbox from 'material-ui/lib/checkbox';
+import FlatButton from 'material-ui/lib/flat-button';
 import TopicFacets from './TopicFacets.jsx';
 import ChildValue from './ChildValue.js';
 import SearchActions from '../../actions/SearchActions.js';
@@ -11,14 +12,28 @@ import { Link } from 'react-router'
 const styles = {
   checkbox: {
     width: "auto",
-    display: "inline-block"
+    display: "inline-block",
+    marginRight: "-16px"
   },
+  button: {
+    textTransform: "none",
+    fontWeight: "700",
+    fontSize: "16px",
+    verticalAlign: "middle", fontFamily: "Helvetica Neue,Helvetica,Arial,sans-serif",
+    minWidth: "initial",
+    lineHeight: "23px",
+    textAlign: "left"
+  },
+  buttonLabel: {
+    paddingLeft: "0px",
+    paddingRight: "0px"
+  }
 };
 
 class TopicFacet extends Component {
   constructor(props) {
     super(props);
-
+    this.forceUpdate = this.forceUpdate.bind(this);
     let searchStr = window.location.search
     this.state = {
       expanded: searchStr.search(this.props.topic.value) > -1,
@@ -27,15 +42,23 @@ class TopicFacet extends Component {
     this.onArrowClick = this.onArrowClick.bind(this);
   }
 
+  componentWillMount() {
+    SearchStore.addChangeListener(this.forceUpdate);
+  }
+
+  componentWillUnmount() {
+    SearchStore.removeChangeListener(this.forceUpdate);
+  }
+
   onArrowClick() {
     this.setState({expanded: !this.state.expanded});
   }
 
   onCheck(e, checked) {
     if(checked){
-      SearchActions.addTopic(this.props.topic.value);
+      SearchActions.addTopics(ChildValue(this.props.topic).split(','));
     } else {
-      SearchActions.removeTopic(this.props.topic.value);
+      SearchActions.removeTopics(ChildValue(this.props.topic).split(','));
     }
   }
 
@@ -71,11 +94,16 @@ class TopicFacet extends Component {
         }
       }
       return (
-        <li style={{ position: 'relative', textIndent: this.props.topic.children ? '0' : '-20px' }}>
-          <div>
-            <Checkbox style={ styles.checkbox } onCheck={ this.onCheck.bind(this) } checked={ SearchStore.hasTopic(this.props.topic.value) }/>
-            <Link to={ this.getLinkPath() }>{this.props.topic.name} </Link>
-            {arrow}
+        <li style={{ position: 'relative', paddingLeft: this.props.topic.children ? '0' : '-20px' }}>
+          <div style={{ display: "inline-flex" }}>
+            <Checkbox style={ styles.checkbox } onCheck={ this.onCheck.bind(this) } defaultChecked={ SearchStore.hasTopic(this.props.topic.value) }/>
+            <FlatButton
+              label={this.props.topic.name}
+              labelPosition="before"
+              labelStyle={ styles.buttonLabel }
+              style={ styles.button }
+              onClick={this.onArrowClick.bind(this)}
+            />{arrow}
           </div>
           <ul style={{
               listStyleType: 'none',

--- a/src/components/Search/TopicFacet.jsx
+++ b/src/components/Search/TopicFacet.jsx
@@ -1,34 +1,11 @@
 'use strict'
 import React, { Component, PropTypes } from 'react';
-import Checkbox from 'material-ui/lib/checkbox';
-import FlatButton from 'material-ui/lib/flat-button';
 import TopicFacets from './TopicFacets.jsx';
 import ChildValue from './ChildValue.js';
 import SearchActions from '../../actions/SearchActions.js';
 import QueryParm from '../../modules/QueryParam.js';
 import SearchStore from '../../store/SearchStore.js';
 import { Link } from 'react-router'
-
-const styles = {
-  checkbox: {
-    width: "auto",
-    display: "inline-block",
-    marginRight: "-16px"
-  },
-  button: {
-    textTransform: "none",
-    fontWeight: "700",
-    fontSize: "16px",
-    verticalAlign: "middle", fontFamily: "Helvetica Neue,Helvetica,Arial,sans-serif",
-    minWidth: "initial",
-    lineHeight: "23px",
-    textAlign: "left"
-  },
-  buttonLabel: {
-    paddingLeft: "0px",
-    paddingRight: "0px"
-  }
-};
 
 class TopicFacet extends Component {
   constructor(props) {
@@ -55,10 +32,10 @@ class TopicFacet extends Component {
   }
 
   onCheck(e, checked) {
-    if(checked){
-      SearchActions.addTopics(ChildValue(this.props.topic).split(','));
-    } else {
+    if(SearchStore.hasTopic(this.props.topic.value)){
       SearchActions.removeTopics(ChildValue(this.props.topic).split(','));
+    } else {
+      SearchActions.addTopics(ChildValue(this.props.topic).split(','));
     }
   }
 
@@ -67,48 +44,50 @@ class TopicFacet extends Component {
     return '/search?q=' + currentSearch[0] + ',' + ChildValue(this.props.topic);
   }
 
-  arrowStyle() {
-    return {
-      fontSize: '20px',
-      verticalAlign: 'middle',
-      color: '#224048',
-      cursor: 'pointer',
-      transform: this.state.expanded ? 'rotate(90deg)' : 'rotate(180deg)',
+  checkbox() {
+    if(SearchStore.hasTopic(this.props.topic.value)) {
+      return (<i className="material-icons topic-checkbox">check_box</i>);
+    } else {
+      return (<i className="material-icons topic-checkbox">check_box_outline_blank</i>);
     }
   }
 
+  arrow() {
+    if(this.props.topic.children) {
+      return (
+        <i
+          className="material-icons topic-arrow"
+          style={{ transform: this.state.expanded ? 'rotate(90deg)' : 'rotate(180deg)' }}
+          onClick={this.onArrowClick.bind(this)}
+          >play_arrow</i>
+      );
+    }
+    return null;
+  }
+
+  children() {
+    if(this.props.topic.children && this.state.expanded) {
+      return (<TopicFacets source={this.props.topic.children} />);
+    }
+    return null;
+  }
+
   render() {
-    let children = null;
-    let arrow = (<div style={{display: 'inline-block', width: '20px'}} />);
     if(this.props.topic){
-      if(this.props.topic.children) {
-        arrow = (
-          <i
-            className="material-icons"
-            style={this.arrowStyle()}
-            onClick={this.onArrowClick.bind(this)}
-            >play_arrow</i>
-        );
-        if(this.state.expanded) {
-          children = (<TopicFacets source={this.props.topic.children} />);
-        }
-      }
       return (
         <li style={{ position: 'relative', paddingLeft: this.props.topic.children ? '0' : '-20px' }}>
           <div style={{ display: "inline-flex" }}>
-            <Checkbox style={ styles.checkbox } onCheck={ this.onCheck.bind(this) } defaultChecked={ SearchStore.hasTopic(this.props.topic.value) }/>
-            <FlatButton
-              label={this.props.topic.name}
-              labelPosition="before"
-              labelStyle={ styles.buttonLabel }
-              style={ styles.button }
-              onClick={this.onArrowClick.bind(this)}
-            />{arrow}
+            <div style={{ cursor: "pointer" }} onClick={ this.onCheck.bind(this) }>
+              { this.checkbox() }
+            </div>
+            <div className="topic-expand" onClick={this.onArrowClick.bind(this)}>
+              <div className="topic-expand-label">{this.props.topic.name}</div>
+              { this.arrow() }
+            </div>
           </div>
-          <ul style={{
-              listStyleType: 'none',
-              paddingLeft: '20px',
-            }}>{children}</ul>
+          <ul style={{ listStyleType: 'none', paddingLeft: '20px' }}>
+            { this.children() }
+          </ul>
         </li>
       );
     }

--- a/src/components/Search/TopicFacet.jsx
+++ b/src/components/Search/TopicFacet.jsx
@@ -3,7 +3,9 @@ import React, { Component, PropTypes } from 'react';
 import Checkbox from 'material-ui/lib/checkbox';
 import TopicFacets from './TopicFacets.jsx';
 import ChildValue from './ChildValue.js';
+import SearchActions from '../../actions/SearchActions.js';
 import QueryParm from '../../modules/QueryParam.js';
+import SearchStore from '../../store/SearchStore.js';
 import { Link } from 'react-router'
 
 const styles = {
@@ -27,6 +29,14 @@ class TopicFacet extends Component {
 
   onArrowClick() {
     this.setState({expanded: !this.state.expanded});
+  }
+
+  onCheck(e, checked) {
+    if(checked){
+      SearchActions.addTopic(this.props.topic.value);
+    } else {
+      SearchActions.removeTopic(this.props.topic.value);
+    }
   }
 
   getLinkPath() {
@@ -63,7 +73,7 @@ class TopicFacet extends Component {
       return (
         <li>
           <div>
-            <Checkbox style={ styles.checkbox } />
+            <Checkbox style={ styles.checkbox } onCheck={ this.onCheck.bind(this) } checked={ SearchStore.hasTopic(this.props.topic.value) }/>
             <Link to={ this.getLinkPath() }>{this.props.topic.name} </Link>
             {arrow}
           </div>

--- a/src/components/Search/TopicFacet.jsx
+++ b/src/components/Search/TopicFacet.jsx
@@ -1,9 +1,17 @@
 'use strict'
 import React, { Component, PropTypes } from 'react';
+import Checkbox from 'material-ui/lib/checkbox';
 import TopicFacets from './TopicFacets.jsx';
 import ChildValue from './ChildValue.js';
 import QueryParm from '../../modules/QueryParam.js';
 import { Link } from 'react-router'
+
+const styles = {
+  checkbox: {
+    width: "auto",
+    display: "inline-block"
+  },
+};
 
 class TopicFacet extends Component {
   constructor(props) {
@@ -32,7 +40,7 @@ class TopicFacet extends Component {
       verticalAlign: 'middle',
       color: '#224048',
       cursor: 'pointer',
-      transform: this.state.expanded ? 'rotate(90deg)' : 'rotate(0deg)',
+      transform: this.state.expanded ? 'rotate(90deg)' : 'rotate(180deg)',
     }
   }
 
@@ -55,8 +63,9 @@ class TopicFacet extends Component {
       return (
         <li>
           <div>
+            <Checkbox style={ styles.checkbox } />
+            <Link to={ this.getLinkPath() }>{this.props.topic.name} </Link>
             {arrow}
-            <Link to={ this.getLinkPath() }>{this.props.topic.name}</Link>
           </div>
           <ul style={{
               listStyleType: 'none',

--- a/src/components/Search/TopicFacets.jsx
+++ b/src/components/Search/TopicFacets.jsx
@@ -11,7 +11,7 @@ class TopicFacets extends Component {
     if(topics) {
       let topicList = topics.map(function(topic, index){
         return(
-          <TopicFacet topic={topic}/>
+          <TopicFacet key={ "topic-" + index } topic={topic}/>
         );
       });
       return topicList;

--- a/src/constants/SearchActionTypes.jsx
+++ b/src/constants/SearchActionTypes.jsx
@@ -1,8 +1,8 @@
 var keyMirror = require('keymirror');
 
 var SearchActionTypes = keyMirror({
-  SEARCH_ADD_TOPIC: null,
-  SEARCH_REMOVE_TOPIC: null,
+  SEARCH_ADD_TOPICS: null,
+  SEARCH_REMOVE_TOPICS: null,
 });
 
 module.exports = SearchActionTypes;

--- a/src/constants/SearchActionTypes.jsx
+++ b/src/constants/SearchActionTypes.jsx
@@ -1,12 +1,8 @@
 var keyMirror = require('keymirror');
 
 var SearchActionTypes = keyMirror({
-  SEARCH_LOAD_RESULTS: null,
-  SEARCH_RELOAD_RESULTS: null,
-  SEARCH_SET_SORT: null,
-  SEARCH_SET_SELECTED_FACET: null,
-  SEARCH_SET_TERM: null,
-  SEARCH_SET_VIEW: null,
+  SEARCH_ADD_TOPIC: null,
+  SEARCH_REMOVE_TOPIC: null,
 });
 
 module.exports = SearchActionTypes;

--- a/src/routes/SearchPage.jsx
+++ b/src/routes/SearchPage.jsx
@@ -3,6 +3,7 @@ import React, { Component, PropTypes } from 'react';
 import BackgroundIcon from 'material-ui/lib/svg-icons/action/find-in-page';
 import Colors from 'material-ui/lib/styles/colors';
 import Search from '../components/Search/Search.jsx';
+import SearchStore from '../store/SearchStore.js';
 import QueryParm from '../modules/QueryParam.js';
 import FacetQueryParms from '../modules/FacetQueryParams.js';
 import HoneycombURL from '../modules/HoneycombURL.js';
@@ -23,6 +24,7 @@ class SearchPage extends Component {
   constructor(props) {
     super(props);
     this.preLoadFinished = this.preLoadFinished.bind(this);
+    this.forceUpdate = this.forceUpdate.bind(this);
     this.state = {
       loaded: ItemStore.preLoaded(),
     };
@@ -37,10 +39,12 @@ class SearchPage extends Component {
   }
 
   componentWillMount() {
+    SearchStore.addChangeListener(this.forceUpdate);
     ItemStore.on("PreLoadFinished", this.preLoadFinished);
   }
 
   componentWillUnmount() {
+    SearchStore.removeChangeListener(this.forceUpdate);
     ItemStore.removeListener("PreLoadFinished", this.preLoadFinished);
   }
 
@@ -50,7 +54,7 @@ class SearchPage extends Component {
 
   renderSearchBody() {
     var searchTerm = QueryParm('q');
-    if(searchTerm == '') {
+    if(searchTerm == '' && SearchStore.topics.length <= 0) {
       return (
         <div className="col-sm-6" style={{ width: "100%" }}>
           <BackgroundIcon style={{ display: "inline-block", width: "150px", height: "150px" }} color={Colors.grey400}/>

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -12,14 +12,26 @@ class SearchStore extends EventEmitter {
     AppDispatcher.register(this.receiveAction.bind(this));
   }
 
-  addTopic(topic) {
-    this._topics[topic] = true;
+  addChangeListener(callback) {
+    this.on("SearchStoreChanged", callback);
+  }
+
+  removeChangeListener(callback) {
+    this.removeListener("SearchStoreChanged", callback);
+  }
+
+  emitChange() {
     this.emit("SearchStoreChanged");
   }
 
-  removeTopic(topic) {
-    delete this._topics[topic];
-    this.emit("SearchStoreChanged");
+  addTopics(topics) {
+    topics.forEach(function(topic) { this._topics[topic] = true }.bind(this));
+    this.emitChange();
+  }
+
+  removeTopics(topics) {
+    topics.forEach(function(topic) { delete this._topics[topic] }.bind(this));
+    this.emitChange();
   }
 
   hasTopic(topic) {
@@ -33,11 +45,11 @@ class SearchStore extends EventEmitter {
   // Receives actions sent by the AppDispatcher
   receiveAction(action) {
     switch(action.actionType) {
-      case SearchActionTypes.SEARCH_ADD_TOPIC:
-        this.addTopic(action.topic);
+      case SearchActionTypes.SEARCH_ADD_TOPICS:
+        this.addTopics(action.topics);
         break;
-      case SearchActionTypes.SEARCH_REMOVE_TOPIC:
-        this.removeTopic(action.topic);
+      case SearchActionTypes.SEARCH_REMOVE_TOPICS:
+        this.removeTopics(action.topics);
         break;
       default:
         break;

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -1,11 +1,3 @@
-// This store retains data on search results retreived from the Honeycomb API.
-// In addition, it also stores some user selections that don't affect the search
-// results, such as the currently clicked item. This is purely so that multiple
-// components can query the store to get this information instead of talking directly
-// to each other. Any time a property changes that will trigger the search results to change,
-// the store will emit a single SearchStoreChanged event, regardless of why it changed.
-// If a property changes that does not change the results, it will emit an individual
-// event specific to that change, such as SearchStoreSelectedItemChanged.
 var AppDispatcher = require("../dispatcher/AppDispatcher.jsx");
 var EventEmitter = require("events").EventEmitter;
 var SearchActionTypes = require("../constants/SearchActionTypes.jsx");
@@ -13,235 +5,43 @@ var SearchActionTypes = require("../constants/SearchActionTypes.jsx");
 class SearchStore extends EventEmitter {
   constructor() {
     super();
-    this._baseApiUrl = "";   // Bases url to use when connecting to the Honeycomb API
-    this._collection = null; // Collection json
-    this._searchTerm = "";   // The primary search term to use when querying the API
-    this._items = [];    // Subset of items returned by the query after filtering on facet, row limit,
-                         // and starting item.
-    this._found = null;  // Total number of items that were found using the search term.
-    this._start = null;  // Start item for the query
-    this._facets = null; // List of facet options available for this collection
-    this._sorts = null;  // List of sort options available for this collection
-    this._count = 0;     // The count of items returned by the current query (<= found since items returned is a subset).
-    this._rowLimit = 12; // The maximum number of items that a query will return.
 
-    // User selections that affect the data
-    this._facetOption = null;
-    this._sortOption = null;
-
-    // User selections that only affect the view (don't require a reload)
-    this._selectedItem = null;
-
-    Object.defineProperty(this, "baseApiUrl", { get: function() { return this._baseApiUrl; } });
-    Object.defineProperty(this, "collection", { get: function() { return this._collection; } });
-    Object.defineProperty(this, "searchTerm", { get: function() { return this._searchTerm; } });
-    Object.defineProperty(this, "items", { get: function() { return this._items; } });
-    Object.defineProperty(this, "found", { get: function() { return this._found; } });
-    Object.defineProperty(this, "start", { get: function() { return this._start; } });
-    Object.defineProperty(this, "facets", { get: function() { return this._facets; } });
-    Object.defineProperty(this, "sorts", { get: function() { return this._sorts; } });
-    Object.defineProperty(this, "count", { get: function() { return this._count; } });
-    Object.defineProperty(this, "rowLimit", { get: function() { return this._rowLimit; } });
-    Object.defineProperty(this, "facetOption", { get: function() { return this._facetOption; } });
-    Object.defineProperty(this, "sortOption", { get: function() { return this._sortOption; } });
-    Object.defineProperty(this, "selectedItem", { get: function() { return this._selectedItem; } });
+    this._topics = {};
+    Object.defineProperty(this, "topics", { get: this.getTopics });
 
     AppDispatcher.register(this.receiveAction.bind(this));
   }
 
-  // This ideally should only need to be called once as part of initialization. Subsequent
-  // calls should change a property and call reload if that property requires reloading data
-  // from the api
-  loadSearchResults(params) {
-    this.setQueryParams(params);
-    this.executeQuery("load");
+  addTopic(topic) {
+    this._topics[topic] = true;
+    this.emit("SearchStoreChanged");
   }
 
-  reloadSearchResults(params) {
-    this.setQueryParams(params);
-    this.executeQuery("reload");
+  removeTopic(topic) {
+    delete this._topics[topic];
+    this.emit("SearchStoreChanged");
   }
 
-  setQueryParams(params) {
-    this._collection = params.collection;
-    this._baseApiUrl = params.baseApiUrl;
-    this._searchTerm = params.searchTerm;
-    this._facetOption = params.facetOption;
-    this._sortOption = params.sortOption;
-    this._start = params.start;
+  hasTopic(topic) {
+    return this._topics[topic];
   }
 
-  getQueryParams() {
-    return {
-      collection: this._collection,
-      baseApiUrl: this._baseApiUrl,
-      searchTerm: this._searchTerm,
-      facetOption: this._facetOption,
-      sortOption: this._sortOption,
-      start: this._start,
-    };
-  }
-
-  executeQuery(reason) {
-    reason = typeof reason != "undefined" ? reason : "load";
-
-    var url = this._baseApiUrl + "?q=" + encodeURIComponent(this._searchTerm);
-    if(this._facetOption !== undefined){
-      for(var i = 0; i < this._facetOption.length; i++) {
-        if(this._facetOption[i].name && this._facetOption[i].value) {
-          url += "&facets[" + this._facetOption[i].name + "]=" + this._facetOption[i].value;
-        }
-      }
-
-    }
-
-    if(this._sortOption) {
-      url += "&sort=" + this._sortOption;
-    }
-    url += "&start=" + this._start;
-    url += "&rows=" + this._rowLimit;
-
-    $.ajax({
-      context: this,
-      type: "GET",
-      url: url,
-      dataType: "json",
-      success: function(result) {
-        this.setItems(result.hits);
-        this.emit("SearchStoreChanged", reason);
-      },
-      error: function(request, status, thrownError) {
-        this.emit("SearchStoreQueryFailed", { request: request, status: status, error: thrownError });
-      }
-    });
-  }
-
-  setTerm(term) {
-    this._searchTerm = term;
-    this.executeQuery();
-  }
-
-  setSelectedFacet(facet) {
-    if(!this._facetOption){
-      this._facetOption = new Array();
-    }
-    // should we add the facet, start by assuming yes we should
-    var addFacet = true;
-    // look for a facet wit the same name
-    // if it is found, delete it
-    // if it has the same name and same value, we don't want to add it so
-    // set addFacet to false
-    for (var i = 0; i < this._facetOption.length; i++) {
-      if(this._facetOption[i].name == facet.name){
-        if(this._facetOption[i].value == facet.value) {
-          addFacet = false;
-        }
-        this._facetOption.splice(i, 1);
-      }
-    }
-    if(addFacet){
-      this._facetOption.push(facet);
-    }
-
-
-    this.executeQuery();
-  }
-
-  setSelectedSort(sort) {
-    this._sortOption = sort;
-    this.executeQuery();
-  }
-
-  // Translates all hits to items. A hit json has a different structure from an item,
-  // and most objects that interact with this store expect an item to look like an item json.
-  setItems(hits) {
-    this._items = [];
-    this._found = hits.found;
-    this._start = hits.start;
-    for (var h in hits.hit) {
-      if (hits.hit.hasOwnProperty(h)){
-        var hit = hits.hit[h];
-        var item = hit;
-        this._items.push(item);
-      }
-    }
-    this._count = this._items.length;
-  }
-
-  // Overrides can be provided to override the value in the store when creating the uri params.
-  // This was primarily created to allow pagination to generate links using the same search, but
-  // with other start values.
-  searchUri(overrides) {
-    var uri = "/search?q=" + this._searchTerm;
-
-    if(this._facetOption && this._facetOption.length > 0) {
-      for (var i = 0; i < this._facetOption.length; i++) {
-        if(this._facetOption[i].name && this._facetOption[i].value) {
-          uri += "&facet[" + this._facetOption[i].name + "]=" + this._facetOption[i].value;
-        }
-      }
-    }
-
-    if(this._sortOption) {
-      uri += "&sort=" + this._sortOption;
-    }
-    if(overrides && overrides.start != "undefined") {
-      uri += "&start=" + overrides.start;
-    } else if(this._start) {
-      uri += "&start=" + this._start;
-    }
-    return uri;
+  getTopics() {
+    return Object.keys(this._topics);
   }
 
   // Receives actions sent by the AppDispatcher
   receiveAction(action) {
     switch(action.actionType) {
-      case SearchActionTypes.SEARCH_LOAD_RESULTS:
-        this.loadSearchResults(action);
+      case SearchActionTypes.SEARCH_ADD_TOPIC:
+        this.addTopic(action.topic);
         break;
-      case SearchActionTypes.SEARCH_RELOAD_RESULTS:
-        this.reloadSearchResults(action.data);
-        break;
-      case SearchActionTypes.SEARCH_SET_TERM:
-        this.setTerm(action.term);
-        break;
-      case SearchActionTypes.SEARCH_SET_SELECTED_FACET:
-        this.setSelectedFacet(action.facet);
-        break;
-      case SearchActionTypes.SEARCH_SET_SORT:
-        this.setSelectedSort(action.sort);
+      case SearchActionTypes.SEARCH_REMOVE_TOPIC:
+        this.removeTopic(action.topic);
         break;
       default:
         break;
     }
-  }
-
-  getNextItem(item) {
-    for(var i = 0; i < this._items.length; ++i) {
-      if(this._items[i]["@id"] == item["@id"]) {
-        var nextI = (i + 1);
-        if(nextI > this._items.length - 1) {
-          return null;
-        } else {
-          return this._items[nextI];
-        }
-      }
-    }
-    return null;
-  }
-
-  getPreviousItem(item) {
-    for(var i = 0; i < this._items.length; ++i) {
-      if(this._items[i]["@id"] == item["@id"]) {
-        var prevI = i - 1;
-        if(prevI < 0) {
-          return null;
-        } else {
-          return this._items[prevI];
-        }
-      }
-    }
-    return null;
   }
 }
 


### PR DESCRIPTION
-Topics now allow multiple selections via checkboxes. Selecting/deselecting a parent will cascade to children. Children can be selected independently of the parent. 
-Search terms will now filter further on the selected topics by using logical ops for the query

There is still a little work to do such as:
1. Preserve/restore topic selections via the url
2. Expand selected topics on render
3. Tweak the appearance of checkboxes/arrows/labels 