### PR TITLE
DEC-912: Bugfix display getting started

### DIFF
--- a/src/actions/SearchActions.js
+++ b/src/actions/SearchActions.js
@@ -36,5 +36,35 @@ class SearchActions {
       topics: topics
     });
   }
+
+  performSearch(collection, topics, searchTerm) {
+    $.ajax({
+      context: this,
+      type: "GET",
+      url:  collection + '/search?q=' + this.buildQuery(topics, searchTerm) + '&rows=10000',
+      dataType: "json",
+      success: function(result) {
+        AppDispatcher.dispatch({
+          actionType: SearchActionTypes.SEARCH_SET_HITS,
+          collection: collection,
+          hits: result.hits
+        });
+      }.bind(this),
+      error: function(request, status, thrownError) {
+        console.log(thrownError);
+      }
+    });
+  }
+
+  // Using logical operators
+  buildQuery(topics, searchTerm) {
+    var qualifiedTopics = topics.map(function(v,i) { return '"' + v +'"' });
+    var unionTopics = qualifiedTopics.join(" OR ");
+    var q = "(" + unionTopics + ")";
+    if(searchTerm != "") {
+      q += " AND \"" + searchTerm + '"';
+    }
+    return encodeURIComponent(q);
+  }
 }
 module.exports = new SearchActions();

--- a/src/actions/SearchActions.js
+++ b/src/actions/SearchActions.js
@@ -56,7 +56,6 @@ class SearchActions {
     });
   }
 
-  // Using logical operators
   buildQuery(topics, searchTerm) {
     var qualifiedTopics = topics.map(function(v,i) { return '"' + v +'"' });
     var unionTopics = qualifiedTopics.join(" OR ");

--- a/src/actions/SearchActions.js
+++ b/src/actions/SearchActions.js
@@ -10,7 +10,7 @@ class SearchActions {
     var topics = topicsParam == null ? [] : decodeURIComponent(topicsParam).split(',');
     var searchTerm = searchTermParam == null ? "" : decodeURIComponent(searchTermParam);
     AppDispatcher.dispatch({
-      actionType: SearchActionTypes.SEARCH_SET_PARAMS,
+      actionType: SearchActionTypes.SEARCH_INI_PARAMS,
       topics: topics,
       searchTerm: searchTerm,
     });

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -16,86 +16,8 @@ var Search = React.createClass({
 
   propTypes: {
     title: React.PropTypes.string,
-    hits: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.array,
-    ]),
-    searchTerm: React.PropTypes.string,
-    sortTerm: React.PropTypes.string,
-    facet: React.PropTypes.oneOfType([
-      React.PropTypes.object,
-      React.PropTypes.array,
-    ]),
-    start: React.PropTypes.number,
-    view: React.PropTypes.string,
-  },
-
-  getInitialState: function() {
-    return ({items: [],})
-  },
-
-  // Callback from LoadRemoteMixin when remote collection is loaded
-  setValues: function(collection) {
-    if(collection && collection.hits){
-      this.setItems(collection.hits);
-    }
-    return true;
-  },
-
-  setItems: function(hits) {
-    var items = [];
-    for (var h in hits.hit) {
-      if (hits.hit.hasOwnProperty(h)){
-        var hit = hits.hit[h];
-        var item = hit;
-        item.collection = this.props.collection
-        items.push(item);
-      }
-    }
-    this.setState({ loading: false, items: items,});
-  },
-
-  componentWillMount: function() {
-    this.loadSearchItems(this.props.collection, this.props.searchTerm);
-  },
-
-  componentWillReceiveProps: function(nextProps) {
-    this.loadSearchItems(nextProps.collection, nextProps.searchTerm);
-  },
-
-  // Using logical operators
-  buildQuery: function(searchTerm) {
-    var qualifiedTopics = SearchStore.topics.map(function(v,i) { return '"' + v +'"' });
-    var unionTopics = qualifiedTopics.join(" OR ");
-    var q = "(" + unionTopics + ")";
-    if(searchTerm != "") {
-      q += " AND \"" + searchTerm + '"';
-    }
-    return encodeURIComponent(q);
-  },
-
-/*
-  // Using comma delimited
-  buildQuery: function(searchTerm) {
-    var q = searchTerm + ',' + SearchStore.topics.join();
-    return encodeURIComponent(q);
-  },
-*/
-
-  loadSearchItems: function(collection, searchTerm) {
-    this.setState({ loading: true });
-    $.ajax({
-      context: this,
-      type: "GET",
-      url:  collection + '/search?q=' + this.buildQuery(searchTerm) + '&rows=10000',
-      dataType: "json",
-      success: function(result) {
-        this.setItems(result.hits);
-      }.bind(this),
-      error: function(request, status, thrownError) {
-        console.log(thrownError);
-      }
-    });
+    collection: React.PropTypes.string,
+    loading: React.PropTypes.bool
   },
 
   render: function() {
@@ -104,8 +26,8 @@ var Search = React.createClass({
     return (
       <div>
         <Heading title={this.props.title} />
-        { this.state.loading && <CircularProgress style={ styles.circleProgress } color={ Colors.blueGrey700 }/> }
-        { !this.state.loading && <SearchDisplayList items={this.state.items}/> }
+        { this.props.loading && <CircularProgress style={ styles.circleProgress } color={ Colors.blueGrey700 }/> }
+        { !this.props.loading && <SearchDisplayList items={SearchStore.getHits(this.props.collection)}/> }
       </div>
     );
   }

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -13,11 +13,40 @@ const styles = {
 };
 
 var Search = React.createClass({
-
   propTypes: {
     title: React.PropTypes.string,
     collection: React.PropTypes.string,
-    loading: React.PropTypes.bool
+  },
+
+  getInitialState: function() {
+    return ({ loading: true });
+  },
+
+  componentWillMount: function() {
+    SearchStore.addResultsChangeListener(this.handleResultsChange);
+    SearchActions.performSearch(this.props.collection, SearchStore.topics, SearchStore.searchTerm);
+  },
+
+  componentWillUnmount: function() {
+    SearchStore.removeResultsChangeListener(this.handleResultsChange);
+  },
+
+  componentWillReceiveProps: function(nextProps){
+    // SearchPage is going to use the router to push a new uri with params anytime the query changes.
+    // Since we rely on the router to rerender these components, rerun the search here
+    // instead of directly listening for query changes from the store
+    this.setState({
+      loading: true,
+    });
+    SearchActions.performSearch(this.props.collection, SearchStore.topics, SearchStore.searchTerm);
+  },
+
+  handleResultsChange: function(collection){
+    if(collection == this.props.collection){
+      this.setState({
+        loading: false,
+      });
+    }
   },
 
   render: function() {
@@ -26,8 +55,8 @@ var Search = React.createClass({
     return (
       <div>
         <Heading title={this.props.title} />
-        { this.props.loading && <CircularProgress style={ styles.circleProgress } color={ Colors.blueGrey700 }/> }
-        { !this.props.loading && <SearchDisplayList items={SearchStore.getHits(this.props.collection)}/> }
+        { this.state.loading && <CircularProgress style={ styles.circleProgress } color={ Colors.blueGrey700 }/> }
+        { !this.state.loading && <SearchDisplayList items={SearchStore.getHits(this.props.collection)}/> }
       </div>
     );
   }

--- a/src/components/Search/SearchBox.jsx
+++ b/src/components/Search/SearchBox.jsx
@@ -1,7 +1,6 @@
 'use strict'
 var React = require('react');
 var mui = require('material-ui');
-var QueryParam = require('../../modules/QueryParam.js');
 var SearchStore = require('../../store/SearchStore.js');
 var SearchActions = require('../../actions/SearchActions.js');
 var VaticanID = require('../../constants/VaticanID.js');

--- a/src/components/Search/TopicFacet.jsx
+++ b/src/components/Search/TopicFacet.jsx
@@ -3,7 +3,6 @@ import _ from 'underscore';
 import React, { Component, PropTypes } from 'react';
 import TopicFacets from './TopicFacets.jsx';
 import SearchActions from '../../actions/SearchActions.js';
-import QueryParm from '../../modules/QueryParam.js';
 import SearchStore from '../../store/SearchStore.js';
 import TopicNode from './TopicNode.js';
 

--- a/src/constants/SearchActionTypes.jsx
+++ b/src/constants/SearchActionTypes.jsx
@@ -2,6 +2,7 @@ var keyMirror = require('keymirror');
 
 var SearchActionTypes = keyMirror({
   SEARCH_SET_PARAMS: null,
+  SEARCH_SET_HITS: null,
   SEARCH_SET_TERM: null,
   SEARCH_ADD_TOPICS: null,
   SEARCH_REMOVE_TOPICS: null,

--- a/src/constants/SearchActionTypes.jsx
+++ b/src/constants/SearchActionTypes.jsx
@@ -1,7 +1,7 @@
 var keyMirror = require('keymirror');
 
 var SearchActionTypes = keyMirror({
-  SEARCH_SET_PARAMS: null,
+  SEARCH_INI_PARAMS: null, // Initializes search parameters without emitting a change event
   SEARCH_SET_HITS: null,
   SEARCH_SET_TERM: null,
   SEARCH_ADD_TOPICS: null,

--- a/src/modules/QueryParam.js
+++ b/src/modules/QueryParam.js
@@ -2,5 +2,5 @@ module.exports = function ( field, url ) {
   var href = url ? url : window.location.href;
   var reg = new RegExp( '[?&]' + field + '=([^&#]*)', 'i' );
   var string = reg.exec(href);
-  return string ? string[1] : null;
+  return string && string[1] != "" ? string[1] : null;
 };

--- a/src/routes/SearchPage.jsx
+++ b/src/routes/SearchPage.jsx
@@ -58,7 +58,6 @@ class SearchPage extends Component {
   }
 
   handleQueryChange(){
-    console.log("SearchPage.handleQueryChange");
     this.setState({
       queryingCatholic: true,
       queryingHumanRights: true,

--- a/src/routes/SearchPage.jsx
+++ b/src/routes/SearchPage.jsx
@@ -5,7 +5,6 @@ import Colors from 'material-ui/lib/styles/colors';
 import Search from '../components/Search/Search.jsx';
 import SearchActions from '../actions/SearchActions.js';
 import SearchStore from '../store/SearchStore.js';
-import QueryParm from '../modules/QueryParam.js';
 import FacetQueryParms from '../modules/FacetQueryParams.js';
 import HoneycombURL from '../modules/HoneycombURL.js';
 import VaticanID from '../constants/VaticanID.js';

--- a/src/routes/SearchPage.jsx
+++ b/src/routes/SearchPage.jsx
@@ -82,14 +82,12 @@ class SearchPage extends Component {
         <div key="catholic" className="col-sm-6">
           <Search
             title = { CATHOLIC }
-            loading = { this.state.queryingCatholic }
             collection={ CATHOLIC_COLLECTION }
           />
         </div>
         <div key="humanrights" className="col-sm-6" style={this.listStyle()}>
           <Search
             title = { HUMANRIGHTS }
-            loading = { this.state.queryingHumanRights }
             collection={ HUMANRIGHTS_COLLECTION }
           />
         </div>

--- a/src/routes/SearchPage.jsx
+++ b/src/routes/SearchPage.jsx
@@ -28,11 +28,8 @@ class SearchPage extends Component {
     super(props, context);
     this.preLoadFinished = this.preLoadFinished.bind(this);
     this.handleQueryChange = this.handleQueryChange.bind(this);
-    this.handleResultsChange = this.handleResultsChange.bind(this);
     this.state = {
       loaded: ItemStore.preLoaded(),
-      queryingCatholic: false,
-      queryingHumanRights: false,
     };
   }
 
@@ -46,38 +43,18 @@ class SearchPage extends Component {
 
   componentWillMount() {
     SearchStore.addQueryChangeListener(this.handleQueryChange);
-    SearchStore.addResultsChangeListener(this.handleResultsChange);
     SearchActions.setParamsFromUri();
     ItemStore.on("PreLoadFinished", this.preLoadFinished);
   }
 
   componentWillUnmount() {
     SearchStore.removeQueryChangeListener(this.handleQueryChange);
-    SearchStore.removeResultsChangeListener(this.handleResultsChange);
     ItemStore.removeListener("PreLoadFinished", this.preLoadFinished);
   }
 
   handleQueryChange(){
-    this.setState({
-      queryingCatholic: true,
-      queryingHumanRights: true,
-    });
-    SearchActions.performSearch(CATHOLIC_COLLECTION, SearchStore.topics, SearchStore.searchTerm);
-    SearchActions.performSearch(HUMANRIGHTS_COLLECTION, SearchStore.topics, SearchStore.searchTerm);
+    // If the query has changed, use the router to update the uri params
     this.context.router.push(SearchStore.searchUri());
-  }
-
-  handleResultsChange(collection){
-    if(collection == CATHOLIC_COLLECTION){
-      this.setState({
-        queryingCatholic: false,
-      });
-    }
-    if(collection == HUMANRIGHTS_COLLECTION){
-      this.setState({
-        queryingHumanRights: false,
-      });
-    }
   }
 
   preLoadFinished() {
@@ -85,8 +62,7 @@ class SearchPage extends Component {
   }
 
   renderSearchBody() {
-    var searchTerm = QueryParm('q');
-    if(searchTerm == '' && SearchStore.topics.length <= 0) {
+    if(SearchStore.searchTerm == '' && SearchStore.topics.length <= 0) {
       return (
         <div className="col-sm-6" style={{ width: "100%" }}>
           <BackgroundIcon style={{ display: "inline-block", width: "150px", height: "150px" }} color={Colors.grey400}/>

--- a/src/routes/SearchPage.jsx
+++ b/src/routes/SearchPage.jsx
@@ -52,6 +52,10 @@ class SearchPage extends Component {
     ItemStore.removeListener("PreLoadFinished", this.preLoadFinished);
   }
 
+  componentWillReceiveProps(nextProps){
+    SearchActions.setParamsFromUri();
+  }
+
   handleQueryChange(){
     // If the query has changed, use the router to update the uri params
     this.context.router.push(SearchStore.searchUri());

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -86,10 +86,9 @@ class SearchStore extends EventEmitter {
   // Receives actions sent by the AppDispatcher
   receiveAction(action) {
     switch(action.actionType) {
-      case SearchActionTypes.SEARCH_SET_PARAMS:
+      case SearchActionTypes.SEARCH_INI_PARAMS:
         this.addTopics(action.topics);
         this._searchTerm = action.searchTerm;
-        this.emitQueryChange();
         break;
       case SearchActionTypes.SEARCH_SET_TERM:
         this._searchTerm = action.searchTerm;

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -87,6 +87,7 @@ class SearchStore extends EventEmitter {
   receiveAction(action) {
     switch(action.actionType) {
       case SearchActionTypes.SEARCH_INI_PARAMS:
+        this._topics = {};
         this.addTopics(action.topics);
         this._searchTerm = action.searchTerm;
         break;

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -12,19 +12,35 @@ class SearchStore extends EventEmitter {
     this._searchTerm = "";
     Object.defineProperty(this, "searchTerm", { get: function() { return this._searchTerm; } });
 
+    this._hits = {};
+
     AppDispatcher.register(this.receiveAction.bind(this));
   }
 
-  addChangeListener(callback) {
-    this.on("SearchStoreChanged", callback);
+  // Adds a callback to listen for changes to the topics or the search term
+  addQueryChangeListener(callback) {
+    this.on("SearchStoreQueryChanged", callback);
   }
 
-  removeChangeListener(callback) {
-    this.removeListener("SearchStoreChanged", callback);
+  removeQueryChangeListener(callback) {
+    this.removeListener("SearchStoreQueryChanged", callback);
   }
 
-  emitChange() {
-    this.emit("SearchStoreChanged");
+  emitQueryChange() {
+    this.emit("SearchStoreQueryChanged");
+  }
+
+  // Adds a callback to listen for changes to the resulting hits for a collection
+  addResultsChangeListener(callback) {
+    this.on("SearchStoreResultsChanged", callback);
+  }
+
+  removeResultsChangeListener(callback) {
+    this.removeListener("SearchStoreResultsChanged", callback);
+  }
+
+  emitResultsChange(collection) {
+    this.emit("SearchStoreResultsChanged", collection);
   }
 
   addTopics(topics) {
@@ -43,6 +59,26 @@ class SearchStore extends EventEmitter {
     return Object.keys(this._topics);
   }
 
+  getHits(collection) {
+    if(this._hits[collection]) {
+      return this._hits[collection];
+    }
+    return null;
+  }
+
+  setHits(collection, hits) {
+    var items = [];
+    for (var h in hits.hit) {
+      if (hits.hit.hasOwnProperty(h)){
+        var hit = hits.hit[h];
+        var item = hit;
+        item.collection = collection
+        items.push(item);
+      }
+    }
+    this._hits[collection] = items;
+  }
+
   searchUri() {
     return '/search?q=' + this._searchTerm + '&t=' + this.getTopics().join(',');
   }
@@ -53,19 +89,23 @@ class SearchStore extends EventEmitter {
       case SearchActionTypes.SEARCH_SET_PARAMS:
         this.addTopics(action.topics);
         this._searchTerm = action.searchTerm;
-        this.emitChange();
+        this.emitQueryChange();
         break;
       case SearchActionTypes.SEARCH_SET_TERM:
         this._searchTerm = action.searchTerm;
-        this.emitChange();
+        this.emitQueryChange();
+        break;
+      case SearchActionTypes.SEARCH_SET_HITS:
+        this.setHits(action.collection, action.hits);
+        this.emitResultsChange(action.collection);
         break;
       case SearchActionTypes.SEARCH_ADD_TOPICS:
         this.addTopics(action.topics);
-        this.emitChange();
+        this.emitQueryChange();
         break;
       case SearchActionTypes.SEARCH_REMOVE_TOPICS:
         this.removeTopics(action.topics);
-        this.emitChange();
+        this.emitQueryChange();
         break;
       default:
         break;


### PR DESCRIPTION
Review and merge https://github.com/ndlib/zucchetto/pull/67 first!




Why: Under certain circumstances, the "getting started" page was not being rendered even though the user had not selected any topics/search terms.
How: There was an assumption made by users of QueryParam that it would return null if there were no params. This was only true if the param was not present. Changed it to also return null if the param is present but has no value (ex: "t=" or "q="). Also found/fixed a bug that occurred anytime the user clicked on "Search Database" from the search page.