### PR TITLE
DEC-912: Bugfix display getting started

### DIFF
--- a/src/components/Search/SearchBox.jsx
+++ b/src/components/Search/SearchBox.jsx
@@ -1,7 +1,6 @@
 'use strict'
 var React = require('react');
 var mui = require('material-ui');
-var QueryParam = require('../../modules/QueryParam.js');
 var SearchStore = require('../../store/SearchStore.js');
 var SearchActions = require('../../actions/SearchActions.js');
 var VaticanID = require('../../constants/VaticanID.js');

--- a/src/components/Search/TopicFacet.jsx
+++ b/src/components/Search/TopicFacet.jsx
@@ -3,7 +3,6 @@ import _ from 'underscore';
 import React, { Component, PropTypes } from 'react';
 import TopicFacets from './TopicFacets.jsx';
 import SearchActions from '../../actions/SearchActions.js';
-import QueryParm from '../../modules/QueryParam.js';
 import SearchStore from '../../store/SearchStore.js';
 import TopicNode from './TopicNode.js';
 

--- a/src/modules/QueryParam.js
+++ b/src/modules/QueryParam.js
@@ -2,5 +2,5 @@ module.exports = function ( field, url ) {
   var href = url ? url : window.location.href;
   var reg = new RegExp( '[?&]' + field + '=([^&#]*)', 'i' );
   var string = reg.exec(href);
-  return string ? string[1] : null;
+  return string && string[1] != "" ? string[1] : null;
 };

--- a/src/routes/SearchPage.jsx
+++ b/src/routes/SearchPage.jsx
@@ -5,7 +5,6 @@ import Colors from 'material-ui/lib/styles/colors';
 import Search from '../components/Search/Search.jsx';
 import SearchActions from '../actions/SearchActions.js';
 import SearchStore from '../store/SearchStore.js';
-import QueryParm from '../modules/QueryParam.js';
 import FacetQueryParms from '../modules/FacetQueryParams.js';
 import HoneycombURL from '../modules/HoneycombURL.js';
 import VaticanID from '../constants/VaticanID.js';

--- a/src/routes/SearchPage.jsx
+++ b/src/routes/SearchPage.jsx
@@ -52,6 +52,10 @@ class SearchPage extends Component {
     ItemStore.removeListener("PreLoadFinished", this.preLoadFinished);
   }
 
+  componentWillReceiveProps(nextProps){
+    SearchActions.setParamsFromUri();
+  }
+
   handleQueryChange(){
     // If the query has changed, use the router to update the uri params
     this.context.router.push(SearchStore.searchUri());

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -87,6 +87,7 @@ class SearchStore extends EventEmitter {
   receiveAction(action) {
     switch(action.actionType) {
       case SearchActionTypes.SEARCH_INI_PARAMS:
+        this._topics = {};
         this.addTopics(action.topics);
         this._searchTerm = action.searchTerm;
         break;


### PR DESCRIPTION
Why: Under certain circumstances, the "getting started" page was not being rendered even though the user had not selected any topics/search terms.
How: There was an assumption made by users of QueryParam that it would return null if there were no params. This was only true if the param was not present. Changed it to also return null if the param is present but has no value (ex: "t=" or "q="). Also found/fixed a bug that occurred anytime the user clicked on "Search Database" from the search page.