### PR TITLE
DEC-902: Bugfix max listeners

### DIFF
--- a/src/components/Document/AddToCompare.jsx
+++ b/src/components/Document/AddToCompare.jsx
@@ -18,12 +18,8 @@ class AddToCompare extends Component {
     }
   }
 
-  componentWillMount() {
-    CompareStore.on('ItemCompareUpdated', this.setStateFromCompareStore);
-  }
-
-  componentWillUnmount() {
-    CompareStore.removeListener("ItemCompareUpdated", this.setStateFromCompareStore);
+  componentWillReceiveProps(nextProps){
+    this.setStateFromCompareStore();
   }
 
   getStateFromCompareStore() {

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -24,7 +24,7 @@ var Search = React.createClass({
   },
 
   componentWillMount: function() {
-    CompareStore.on('ItemCompareUpdated', this.forceUpdate.bind(this));
+    CompareStore.on("ItemCompareUpdated", this.forceUpdate.bind(this));
     SearchStore.addResultsChangeListener(this.handleResultsChange);
     SearchActions.performSearch(this.props.collection, SearchStore.topics, SearchStore.searchTerm);
   },

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -3,6 +3,7 @@ var React = require('react');
 var CircularProgress = require('material-ui/lib/circular-progress');
 var Colors = require('material-ui/lib/styles/colors');
 var PageContent = require('../../layout/PageContent.jsx');
+var CompareStore = require("../../store/CompareStore.js");
 var SearchStore = require('../../store/SearchStore.js');
 var SearchActions = require('../../actions/SearchActions.js');
 var SearchDisplayList = require('./SearchDisplayList.jsx');
@@ -23,11 +24,13 @@ var Search = React.createClass({
   },
 
   componentWillMount: function() {
+    CompareStore.on('ItemCompareUpdated', this.forceUpdate.bind(this));
     SearchStore.addResultsChangeListener(this.handleResultsChange);
     SearchActions.performSearch(this.props.collection, SearchStore.topics, SearchStore.searchTerm);
   },
 
   componentWillUnmount: function() {
+    CompareStore.removeListener("ItemCompareUpdated", this.forceUpdate);
     SearchStore.removeResultsChangeListener(this.handleResultsChange);
   },
 

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -24,13 +24,13 @@ var Search = React.createClass({
   },
 
   componentWillMount: function() {
-    CompareStore.on("ItemCompareUpdated", this.forceUpdate.bind(this));
+    CompareStore.on("ItemCompareUpdated", this.handleCompareChange);
     SearchStore.addResultsChangeListener(this.handleResultsChange);
     SearchActions.performSearch(this.props.collection, SearchStore.topics, SearchStore.searchTerm);
   },
 
   componentWillUnmount: function() {
-    CompareStore.removeListener("ItemCompareUpdated", this.forceUpdate);
+    CompareStore.removeListener("ItemCompareUpdated", this.handleCompareChange);
     SearchStore.removeResultsChangeListener(this.handleResultsChange);
   },
 
@@ -50,6 +50,10 @@ var Search = React.createClass({
         loading: false,
       });
     }
+  },
+
+  handleCompareChange: function(){
+    this.forceUpdate();
   },
 
   render: function() {


### PR DESCRIPTION
Why: We're getting warnings about potential memory leaks because of all of the listeners that are registered for the same message in the EventEmitter.
How: Moved the listeners from each individual checkbox to the top level search object. Now, when any item is added/removed from comparison, the Search component will rerender all children. Their states should remain the same, so this should not affect things like changing the state of expanded cards, and it will reduce the number of listeners to two.