### PR TITLE
DEC-913: Query cleanup

### DIFF
--- a/src/actions/SearchActions.js
+++ b/src/actions/SearchActions.js
@@ -57,11 +57,17 @@ class SearchActions {
   }
 
   buildQuery(topics, searchTerm) {
-    var qualifiedTopics = topics.map(function(v,i) { return '"' + v +'"' });
-    var unionTopics = qualifiedTopics.join(" OR ");
-    var q = "(" + unionTopics + ")";
-    if(searchTerm != "") {
-      q += " AND \"" + searchTerm + '"';
+    var q = "";
+    if(topics.length > 0) {
+      var qualifiedTopics = topics.map(function(v,i) { return '"' + v +'"' });
+      var unionTopics = qualifiedTopics.join(" OR ");
+      q += "(" + unionTopics + ")";
+    }
+    if(searchTerm !== "") {
+      if(q !== ""){
+        q += " AND ";
+      }
+      q += searchTerm;
     }
     return encodeURIComponent(q);
   }


### PR DESCRIPTION
- Changed the query to no longer populate `() AND` if the topics selection is empty
- Changed the search term to no longer look for the exact phrase. The user can still qualify a phrase with quotes if they require an exact match.
- I was unable to recreate the double encoding that I found before. At one point we were getting `%2520` which suggests an `encode(encode(" "))` was occurring, but I could not recreate it, so this does not fix.