### PR TITLE
DEC-873 Place view doc / PDF link on doc modal

### DIFF
--- a/src/assets/css/document.scss
+++ b/src/assets/css/document.scss
@@ -20,7 +20,7 @@ body {
 }
 
 .document-head {
-  
+
   background-color: $documentBackground;
   margin: 0.5em 0;
   padding: 0.2em 1em;
@@ -121,7 +121,7 @@ body {
   box-shadow: inset 0 0 3px #999;
 
   h3 {
-    margin-top:0; 
+    margin-top:0;
     margin-bottom: 20px;
     float: left;
   }
@@ -154,4 +154,18 @@ body {
       font-size:14px;
     }
   }
+}
+
+.view-document {
+  font-size: 14px;
+  color: #224048;
+  cursor: pointer;
+  padding: 1px;
+}
+
+.view-document-icon {
+  font-size: 16px;
+  vertical-align: middle;
+  color: #224048;
+  cursor: pointer;
 }

--- a/src/components/Document/Document.jsx
+++ b/src/components/Document/Document.jsx
@@ -8,6 +8,7 @@ import Title from './Title.jsx';
 import DownloadPDF from './DownloadPDF.jsx';
 import CurrentParagraph from './CurrentParagraph.jsx';
 import CopyrightNotification from './CopyrightNotification.jsx';
+import ViewOriginal from './ViewOriginal.jsx';
 import CompareStore from '../../store/CompareStore.js';
 import ParagraphJumpList from './ParagraphJumpList.jsx';
 
@@ -86,6 +87,7 @@ class Document extends Component {
             primaryAction={ this.selectParagraph }
           />
           <CopyrightNotification item={ this._parent } />
+          <ViewOriginal item={ this._parent } />
         </div>
         <div className="document" ref={"document-" + this._parent.id}>
           <div style={ this.props.bodyStyle } >

--- a/src/components/Document/DocumentCard.jsx
+++ b/src/components/Document/DocumentCard.jsx
@@ -14,9 +14,7 @@ import MenuItem from 'material-ui/lib/menus/menu-item';
 
 
 const iconButtonElement = (
-  <IconButton
-    touch={true}
-  >
+  <IconButton touch={true}>
     <MoreVertIcon color={Colors.grey400} />
   </IconButton>
 );
@@ -36,16 +34,8 @@ class DocumentCard extends Component {
     this.props.primaryAction(event, this._doc);
   }
 
-  moreAction(event, child) {
-    switch(child.key) {
-      case "ViewDocument":
-        this.refs.DocumentDialog.handleOpen(child.props.documentId);
-        break;
-      case "DownloadPDF":
-        break;
-      default:
-        break;
-    }
+  viewDocument(event) {
+    this.refs.DocumentDialog.handleOpen(this._doc.id);
   }
 
   render() {
@@ -54,11 +44,9 @@ class DocumentCard extends Component {
     return (
       <div className="document">
         <DocumentDialog ref="DocumentDialog"/>
-        <div style={{ float: "right "}}>
-          <IconMenu iconButtonElement={iconButtonElement} onItemTouchTap={ this.moreAction.bind(this) }>
-            <MenuItem key="ViewDocument" documentId={ this._doc.id }>View Document</MenuItem>
-            <MenuItem key="DownloadPDF">Download PDF</MenuItem>
-          </IconMenu>
+        <div style={{ float: "right "}} className="view-document" onClick={ this.viewDocument.bind(this) }>
+          <i className="material-icons view-document-icon">description</i>
+          <span>Full Document</span>
         </div>
         <div  style={{cursor: 'pointer'}} onClick={this.primaryAction}>
           <Title item={this._doc} />

--- a/src/components/Document/ViewOriginal.jsx
+++ b/src/components/Document/ViewOriginal.jsx
@@ -1,0 +1,22 @@
+'use strict'
+import React, { Component, PropTypes } from 'react';
+
+class ViewOriginal extends Component {
+
+  render() {
+    if (this.props.item.metadata.url) {
+      return (
+        <p>
+          <a href={ this.props.item.metadata.url.values[0].value } target="_blank" className="view-original">View PDF</a>
+        </p>
+      );
+    }
+    return (<div />);
+  }
+}
+
+ViewOriginal.propTypes = {
+  item: React.PropTypes.object,
+}
+
+export default ViewOriginal;


### PR DESCRIPTION
What: We no longer needed the dotted menu on the results cards. That was replaced with a view document link. The view PDF option was moved to the full document modal in the upper left corner.