### PR TITLE
DEC-1229 Footnotes display

### DIFF
--- a/src/components/Document/Document.jsx
+++ b/src/components/Document/Document.jsx
@@ -9,6 +9,7 @@ import DocumentType from './DocumentType.jsx';
 import CurrentParagraph from './CurrentParagraph.jsx';
 import CopyrightNotification from './CopyrightNotification.jsx';
 import AddToCompare from './AddToCompare.jsx';
+import FootNotes from './FootNotes.jsx';
 
 class Document extends Component {
   constructor(props) {
@@ -65,6 +66,7 @@ class Document extends Component {
           { this.props.children }
           <DocumentType item={this._parent} />
           { this.paragraphs() }
+          <FootNotes item={ this._parent } />
           <CopyrightNotification item={ this._parent } />
         </div>
       </div>

--- a/src/components/Document/FootNotes.jsx
+++ b/src/components/Document/FootNotes.jsx
@@ -1,0 +1,24 @@
+'use strict'
+import React, { Component, PropTypes } from 'react'
+
+class FootNotes extends Component {
+
+  constructor(props) {
+    super(props)
+  }
+
+  render() {
+    if(this.props.item && this.props.item.metadata && this.props.item.metadata.footnotes) {
+      return (
+        <div dangerouslySetInnerHTML={ { __html: this.props.item.metadata.footnotes.values[0].value } } />
+      )
+    }
+    return null
+  }
+}
+
+FootNotes.propTypes = {
+  item: PropTypes.object,
+}
+
+export default FootNotes

--- a/src/components/Document/MetadataSection.jsx
+++ b/src/components/Document/MetadataSection.jsx
@@ -25,7 +25,7 @@ class MetadataSection extends Component {
         <p key={ prop } ><span style={{ fontFamily: 'sans-serif', fontWeight: 'bold'}}>{label}:</span> {value}</p>
       );
 
-      if(label !== 'Coverage Temporal') {
+      if(label !== 'Coverage Temporal' && label !=='Footnotes') {
         data.push({label: label.toLowerCase(), value: html});
       }
     }


### PR DESCRIPTION
Displaying footnotes was a high priority requested feature. Since the data did not contain any actual footnote metadata until recently we were unable to format it. Now that the data exists the following changes have been made:

* Hide footnotes from metadata display section
* Add footnotes to document viewing