### PR TITLE
Bugfix: Ecclesia document not rendering

### DIFF
--- a/src/components/Document/Document.jsx
+++ b/src/components/Document/Document.jsx
@@ -53,7 +53,7 @@ class Document extends Component {
           item={ item }
           selected={ selected }
           highlighted = { highlighted }
-          showCheckBoxes={ ( item.metadata.type_of_text.values[0].value === 'BodyText' && this.props.showCompareButton ) }
+          showCheckBoxes={ ( item.metadata.type_of_text && item.metadata.type_of_text.values[0].value === 'BodyText' && this.props.showCompareButton ) }
         />
       </div>
     );


### PR DESCRIPTION
The problem is due to the item not having a "Type of Text" value. I've changed it to prevent crashing, but it may cause hidden issues. Ex: One paragraph within a large document will not have a compare button, without any discernible reason to the user.