### PR TITLE
Alter document header width

### DIFF
--- a/src/components/Document/DocumentToolbar.jsx
+++ b/src/components/Document/DocumentToolbar.jsx
@@ -27,7 +27,7 @@ class DocumentToolbar extends Component {
         <ToolbarTitle text={ this.props.document.name }
           style={{
             fontSize: '16px',
-            maxWidth: 'calc(100vw - 570px)',
+            maxWidth: 'calc(100vw - 600px)',
             whiteSpace: 'nowrap',
             overflowX: 'hidden',
             textOverflow: 'ellipsis',


### PR DESCRIPTION
The "back" button got longer, but the document name limit wasn't changed to match so it could push the buttons to the next line. This should fix that.