### PR TITLE
Remove caching

### DIFF
--- a/awsbuild.sh
+++ b/awsbuild.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 BUCKET=csthr.library.nd.edu
-HONEYCOMB=https://honeycomb.library.nd.edu
 RELEASE=`git fetch --tags;git show remotes/origin/master:current_release`
 TAG=`git describe --exact-match --tags HEAD`
 REVISION=`git rev-parse HEAD`
@@ -14,9 +13,6 @@ echo "\033[0;31mBuilding production with tag ${TAG} (Rev ${REVISION})\033[0m"
 npm run build
 echo ${REVISION} > public/REVISION
 cd ./public
-
-curl -o ./resources/cache_data/cst_data.json ${HONEYCOMB}/v1/collections/vatican/items
-curl -o ./resources/cache_data/ihrl_data.json ${HONEYCOMB}/v1/collections/humanrights/items
 
 aws s3 sync . s3://${BUCKET} --exclude '.*' --exclude '*.md' --delete --acl public-read
 echo "\033[0;31mDeployed to ${BUCKET}.s3-website-us-east-1.amazonaws.com. Rebuilding for development.\033[0m"

--- a/awsbuild_pprd.sh
+++ b/awsbuild_pprd.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 BUCKET=csthr-pprd.library.nd.edu
-HONEYCOMB=https://honeycombpprd-vm.library.nd.edu
 BRANCH=`git rev-parse --abbrev-ref HEAD`
 REVISION=`git rev-parse HEAD`
 
@@ -8,9 +7,6 @@ echo "\033[0;31mBuilding preproduction on branch ${BRANCH}\033[0m"
 npm run build-pprd
 echo ${REVISION} > public/REVISION
 cd ./public
-
-curl -o ./resources/cache_data/cst_data.json ${HONEYCOMB}/v1/collections/vatican/items
-curl -o ./resources/cache_data/ihrl_data.json ${HONEYCOMB}/v1/collections/humanrights/items
 
 aws s3 sync . s3://${BUCKET} --exclude '.*' --exclude '*.md' --delete --acl public-read --profile "testlibnd-superAdmin"
 echo "\033[0;31mDeployed to ${BUCKET}.s3-website-us-east-1.amazonaws.com. Rebuilding for development.\033[0m"

--- a/build_cache.sh
+++ b/build_cache.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-ENV_ALIAS=honeycomb
-
-mkdir ./public/resources/cache_data
-
-curl -o ./public/resources/cache_data/cst_data.json https://${ENV_ALIAS}.library.nd.edu/v1/collections/vatican/items
-curl -o ./public/resources/cache_data/ihrl_data.json https://${ENV_ALIAS}.library.nd.edu/v1/collections/humanrights/items
-
-npm run build-dev

--- a/src/actions/ItemActions.jsx
+++ b/src/actions/ItemActions.jsx
@@ -24,9 +24,6 @@ class ItemActions {
     var vaticanUrl = HoneycombURL() + "/v1/collections/vatican/items";
     var humanrightsUrl = HoneycombURL() + "/v1/collections/humanrights/items";
 
-    vaticanUrl = "/resources/cache_data/cst_data.json";
-    humanrightsUrl = "/resources/cache_data/ihrl_data.json";
-
     $.ajax({
       context: this,
       type: "GET",


### PR DESCRIPTION
Removed the json fetch from the build scripts, and reverted ItemActions back to querying the api. This should remove our dependency on the build scripts for fetching data.