### PR TITLE
Button to clear selected from the search page

### DIFF
--- a/src/components/Notebook/Notebook.jsx
+++ b/src/components/Notebook/Notebook.jsx
@@ -104,7 +104,7 @@ class Notebook extends Component {
 
     return (
       <div>
-        <Header />
+        <Header showCompareActions={ false }/>
         <NotebookToolbar />
         <div className="row body" style={{ height: this.state.height, backgroundColor: 'white' }}>
           <div className="col-sm-3 left-col" style={{ backgroundColor: '#f8f6ed' }}>

--- a/src/components/StaticAssets/ClearNotebookHeaderButton.jsx
+++ b/src/components/StaticAssets/ClearNotebookHeaderButton.jsx
@@ -1,0 +1,65 @@
+'use strict'
+import React, { Component, PropTypes } from 'react';
+import mui, { Dialog, FlatButton, FontIcon } from 'material-ui';
+import Colors from 'material-ui/lib/styles/colors';
+import CompareActions from '../../actions/CompareActions.js';
+import CompareStore from '../../store/CompareStore.js';
+
+class ClearNotebookHeaderButton extends Component {
+
+  constructor(props) {
+    super(props);
+    this.updateCount = this.updateCount.bind(this);
+    this.onClick = this.onClick.bind(this);
+    this.state = {
+      totalCount: CompareStore.allItems().length,
+    }
+  }
+
+  onClick() {
+    CompareActions.clearItems();
+  }
+
+  componentWillMount() {
+    CompareStore.on('ItemCompareUpdated', this.updateCount);
+  }
+
+  componentWillUnmount() {
+    CompareStore.removeListener('ItemCompareUpdated', this.updateCount);
+  }
+
+  disabled() {
+    return (this.state.totalCount == 0);
+  }
+
+  updateCount() {
+    this.setState({ totalCount: CompareStore.allItems().length })
+  }
+
+  render() {
+    return (
+      <FlatButton
+        onClick={ this.onClick }
+        label="Clear all"
+        icon={ <FontIcon className="material-icons" style={{ margin: '4px 12px' }}>delete</FontIcon> }
+        style={{
+          backgroundColor: this.disabled() ? '#224048': Colors.red900,
+          color: this.disabled() ? '#cdcdcd' : 'white',
+          cursor: this.disabled() ? 'default' :'pointer',
+          fontFamily: 'Roboto,​sans-serif',
+          fontSize: '0.9em',
+          margin: '0 0',
+          padding: '0 16px',
+          textAlign: 'center',
+          textTransform: 'uppercase',
+          lineHeight: '50px',
+          borderLeft: '1px solid white',
+          borderRight: '1px solid white'
+        }}
+      />
+
+    );
+  }
+}
+
+export default ClearNotebookHeaderButton;

--- a/src/components/StaticAssets/Header.jsx
+++ b/src/components/StaticAssets/Header.jsx
@@ -3,6 +3,8 @@ import React, { Component, PropTypes } from 'react';
 import { browserHistory } from 'react-router';
 import mui, { AppBar, FlatButton, FontIcon, LeftNav } from 'material-ui';
 import NotebookLink from "../Notebook/NotebookLink.jsx"
+import ClearNotebookHeaderButton from "./ClearNotebookHeaderButton.jsx"
+
 import { Link } from 'react-router'
 import Navigation from './Navigation.jsx'
 
@@ -11,6 +13,17 @@ class Header extends Component {
     super();
     this.state = { menuOpen: false }
     this.menuClick = this.menuClick.bind(this);
+  }
+
+  actionButtons() {
+    if(this.props.showCompareActions)
+      return (
+        <div style={{ marginTop: '-8px' }}>
+          <NotebookLink />
+          <ClearNotebookHeaderButton />
+        </div>
+      );
+    return null;
   }
 
   menuClick() {
@@ -54,7 +67,7 @@ class Header extends Component {
             lineHeight: '50px',
           }}
           iconElementLeft={ icon }
-          iconElementRight={ (<div style={{marginTop: '-8px'}}><NotebookLink /></div>) }
+          iconElementRight={ this.actionButtons() }
 
         />
         <LeftNav
@@ -85,6 +98,14 @@ class Header extends Component {
 
     );
   }
+}
+
+Header.propTypes = {
+  showCompareActions: React.PropTypes.bool,
+}
+
+Header.defaultProps = {
+  showCompareActions: true,
 }
 
 export default Header;

--- a/src/store/CompareStore.js
+++ b/src/store/CompareStore.js
@@ -39,6 +39,7 @@ class CompareStore extends EventEmitter {
   }
 
   validStore() {
+    return true;
     if(!this.validCollection(VaticanID) || !this.validCollection(HumanRightsID)) {
       return false;
     }


### PR DESCRIPTION
- Added a clear button to the header.
- Changed Header to accept an optional param to disable the clear notebook/notebook link buttons when on the Notebook page. Contextually they don't make sense here, and I had problems with the clear button not refreshing the page since the current expectation on the Notebook page when clearing docs is that it would push a new url to the history, which this button can't do. If we absolutely need it we'll have to rewrite the way that message propagates to the children of Notebook.