### PR TITLE
Fix scrollbar and sort alignment on windows

### DIFF
--- a/src/components/Search/SearchSort.jsx
+++ b/src/components/Search/SearchSort.jsx
@@ -52,7 +52,6 @@ var SearchSort = React.createClass({
   sortSelectStyle: function() {
     return ({
       background: 'transparent',
-      padding: '7px 8px',
       border: 'none',
       boxShadow: 'none',
       appearance: 'none',


### PR DESCRIPTION
DEC-1359 - scrollbar on entire search page on windows
DEC-1364 - sort box too big/not aligned on windows

This padding wasn't displaying on apple machines, but was causing issues on windows.