### PR TITLE
DEC-1381

### DIFF
--- a/src/components/Search/topics.js
+++ b/src/components/Search/topics.js
@@ -456,7 +456,7 @@ module.exports = {
           children: [
             { name: 'As Human Persons', value: 'As Human Persons' },
             { name: 'As Juridical Persons', value: 'As Juridical Persons' },
-            { name: 'Economic', value: 'Economic' },
+            { name: 'Economic Equality', value: 'Economic Equality' },
             { name: 'Equality of Opportunity', value: 'Equality of Opportunity' },
             { name: 'Equality of Outcome', value: 'Equality of Outcome' },
             { name: 'Social/Political', value: 'Social Political' },


### PR DESCRIPTION
__NOTE__: This only address the duplication in the interface. In order for differing results to be returned, the database will need to be updated with the new key term 'Economic Equality'.

DEC-1381 Description from JIRA:

Similar terms under two different sections on the topic list searching one forces the other to search as well. Example is Development/Human Flourshing if you choose economic it highlights Equality Economic as well. These are two different topics so both results should not be returned. May be able to fix by changing the name of economic. Christina will provide image and new name.

After more thorough review of the topic list there are a few other instances when this same things occurs. A user chooses for example "Family Rights" under one heading and it is automatically chosen under another heading. This is fine for all instances of this except Economic. So under "Principles and Values — Equality — Economic" let's change "Economic" to "Economic Equality"

