### PR TITLE
Correctly OR topics

### DIFF
--- a/src/actions/SearchActions.js
+++ b/src/actions/SearchActions.js
@@ -109,8 +109,8 @@ class SearchActions {
     var q = "";
     if(topics.length > 0) {
       var qualifiedTopics = topics.map(function(v,i) { return v });
-      var unionTopics = qualifiedTopics.join(" OR ");
-      q += "actors_t:(" + unionTopics + ")";
+      var unionTopics = qualifiedTopics.join(") OR (");
+      q += "actors_t:((" + unionTopics + "))";
     }
     if(searchTerm !== "") {
       if(q !== ""){


### PR DESCRIPTION
Some topics, particularly those containing the keyword AND in them, were not being ored together correctly. This change should make sure all topics are contained in their own space and dont mess with the query keywords.