### PR TITLE
Search string update

### DIFF
--- a/src/actions/SearchActions.js
+++ b/src/actions/SearchActions.js
@@ -40,6 +40,12 @@ class SearchActions {
     });
   }
 
+  emitChange(searchTerm){
+    AppDispatcher.dispatch({
+      actionType: SearchActionTypes.SEARCH_EMIT_CHANGE,
+    });
+  }
+
   setSort(sort) {
     AppDispatcher.dispatch({
       actionType: SearchActionTypes.SEARCH_SET_SORT,

--- a/src/components/Search/SearchBox.jsx
+++ b/src/components/Search/SearchBox.jsx
@@ -37,10 +37,12 @@ var SearchBox = React.createClass({
 
   onClick: function(e) {
     SearchActions.setTerm(this.state.searchTerm);
+    SearchActions.emitChange();
   },
 
   setTerm: function(term) {
     this.setState({ searchTerm: term });
+    SearchActions.setTerm(term);
   },
 
   inputStyle: function() {
@@ -52,7 +54,7 @@ var SearchBox = React.createClass({
   handleKeyDown: function(e) {
     var ENTER = 13;
     if( e.keyCode == ENTER ) {
-        this.onClick(e);
+        SearchActions.emitChange();
     }
   },
 

--- a/src/components/Search/TokenSearchBox.jsx
+++ b/src/components/Search/TokenSearchBox.jsx
@@ -75,6 +75,7 @@ var TokenSearchBox = React.createClass({
       terms.push(this.state.selected[i].id)
     }
     SearchActions.setTerm(terms.join(','));
+    SearchActions.emitChange();
   },
 
   filterTags: function(userInput) {

--- a/src/constants/SearchActionTypes.jsx
+++ b/src/constants/SearchActionTypes.jsx
@@ -2,6 +2,7 @@ var keyMirror = require('keymirror');
 
 var SearchActionTypes = keyMirror({
   SEARCH_INI_PARAMS: null, // Initializes search parameters without emitting a change event
+  SEARCH_EMIT_CHANGE: null,
   SEARCH_SET_HITS: null,
   SEARCH_SET_TERM: null,
   SEARCH_ADD_TOPICS: null,

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -267,9 +267,11 @@ class SearchStore extends EventEmitter {
           maxDate: action.maxDate,
         });
         break;
+      case SearchActionTypes.SEARCH_EMIT_CHANGE:
+        this.emitQueryChange();
+        break;
       case SearchActionTypes.SEARCH_SET_TERM:
         this._searchTerm = action.searchTerm;
-        this.emitQueryChange();
         break;
       case SearchActionTypes.SEARCH_SET_HITS:
         this.setHits(action.collection, action.hits);


### PR DESCRIPTION
Changing search string without confirming the change, then selecting a topic will now update the url to use the correct search string

Anytime the search string changes the store is now updated, but no query change event is fired. Query changes are now possible to fire separately and are done so on the appropriate actions (click search, press enter).