### PR TITLE
DEC-1441 & DEC-1438 Break crowdsourcing buttons into groups & feedback updates

### DIFF
--- a/src/components/Document/CrowdSourcing.jsx
+++ b/src/components/Document/CrowdSourcing.jsx
@@ -57,22 +57,20 @@ class CrowdSourcing extends Component {
   }
 
   setActors(item) {
-    let filteredActors = []
-    let sortedActors = []
+    let actors = []
     if(item.items.metadata && item.items.metadata.actors) {
       const regex = new RegExp(/^((?![a-z]\d{1,3})).*/gim)
-      
-      // Filter out a bunch of null values
+
       // Remove actors with generated, non-descritive names e.g. a201, h300
-      filteredActors = item.items.metadata.actors.values.filter((actor) => {
+      actors = item.items.metadata.actors.values.filter((actor) => {
+        // Filter out a bunch of null values
         return actor.value.match(regex) !== null
       }).map((actor) => {
         return actor.value.match(regex)
       })
-      // Sort into groups
-      sortedActors = this.sortActors(filteredActors)
+
     }
-    this.setState({actors: sortedActors, actorsSet: true})
+    this.setState({actors: this.sortActors(actors), actorsSet: true})
   }
 
   render() {

--- a/src/components/Document/CrowdSourcing.jsx
+++ b/src/components/Document/CrowdSourcing.jsx
@@ -57,26 +57,20 @@ class CrowdSourcing extends Component {
   }
 
   setActors(item) {
-    let unsortedActors = []
     let filteredActors = []
     let sortedActors = []
     if(item.items.metadata && item.items.metadata.actors) {
-      filteredActors = item.items.metadata.actors.values.filter((actor) => {
-        const regex = new RegExp(/^((?![a-z]\d{1,3})).*/gim)
-        const val = actor.value.match(regex)
-        return val !== null
-      })
+      const regex = new RegExp(/^((?![a-z]\d{1,3})).*/gim)
+      
+      // Filter out a bunch of null values
       // Remove actors with generated, non-descritive names e.g. a201, h300
-      unsortedActors = filteredActors.map((actor) => {
-        const regex = new RegExp(/^((?![a-z]\d{1,3})).*/gim)
-        const val = actor.value.match(regex)
-        if(val !== undefined) {
-          return actor.value.match(regex)
-        }
+      filteredActors = item.items.metadata.actors.values.filter((actor) => {
+        return actor.value.match(regex) !== null
+      }).map((actor) => {
+        return actor.value.match(regex)
       })
       // Sort into groups
-      sortedActors = this.sortActors(unsortedActors)
-
+      sortedActors = this.sortActors(filteredActors)
     }
     this.setState({actors: sortedActors, actorsSet: true})
   }

--- a/src/components/Document/CrowdSourcing.jsx
+++ b/src/components/Document/CrowdSourcing.jsx
@@ -45,9 +45,9 @@ class CrowdSourcing extends Component {
       let assigned = false
       let index = 0
       while (!assigned && index < sortedActors.length) {
-        if(_.where(this.state.topicArrays[index], {name: actor[0].trim()}).length > 0) {
+        if(_.where(this.state.topicArrays[index], {name: actor.value.trim()}).length > 0) {
           assigned = true
-          sortedActors[index].push(actor)
+          sortedActors[index].push(actor.value.trim())
         }
         index += 1
       }
@@ -65,8 +65,6 @@ class CrowdSourcing extends Component {
       actors = item.items.metadata.actors.values.filter((actor) => {
         // Filter out a bunch of null values
         return actor.value.match(regex) !== null
-      }).map((actor) => {
-        return actor.value.match(regex)
       })
 
     }
@@ -90,7 +88,7 @@ class CrowdSourcing extends Component {
               (actor) => {
                 buttons.push(
                   <CrowdSourcingButton
-                    actor={actor.join()}
+                    actor={actor}
                     doc={this.state.doc}
                     item={this.props.item}
                     marked={false}

--- a/src/components/Document/CrowdSourcing.jsx
+++ b/src/components/Document/CrowdSourcing.jsx
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 import CrowdSourcingButton from './CrowdSourcingButton.jsx'
 import ItemStore from '../../store/ItemStore.js'
 import IDFromAtID  from '../../modules/IDFromAtID.js';
+import topics from '../Search/topics.js'
+import _ from 'underscore'
+import flattenTreeToArray from '../../modules/FlattenTreeToArray.js'
 
 class CrowdSourcing extends Component {
   constructor(props) {
@@ -11,11 +14,18 @@ class CrowdSourcing extends Component {
     let documentId = IDFromAtID(this.props.item['isPartOf/item'])
     let doc = ItemStore.getItem(documentId)
     this.state = {
-      actors: [],
+      actors: [[],[],[],[]],
       actorsSet: false,
       doc: doc,
       uuid: localStorage.getItem('UUID'),
+      topicArrays: [
+        flattenTreeToArray(topics.topics[0].children, []),
+        flattenTreeToArray(topics.topics[1].children, []),
+        flattenTreeToArray(topics.topics[2].children, []),
+        flattenTreeToArray(topics.topics[3].children, [])
+      ]
     }
+    this.sortActors = this.sortActors.bind(this)
   }
 
   componentWillMount() {
@@ -29,9 +39,27 @@ class CrowdSourcing extends Component {
 
   }
 
+  sortActors(actors) {
+    let sortedActors = [[], [], [], []]
+    actors.forEach((actor) => {
+      let assigned = false
+      let index = 0
+      while (!assigned && index < sortedActors.length) {
+        if(_.where(this.state.topicArrays[index], {name: actor[0].trim()}).length > 0) {
+          assigned = true
+          sortedActors[index].push(actor)
+        }
+        index += 1
+      }
+
+    })
+    return sortedActors
+  }
+
   setActors(item) {
-    let actors = []
+    let unsortedActors = []
     let filteredActors = []
+    let sortedActors = []
     if(item.items.metadata && item.items.metadata.actors) {
       filteredActors = item.items.metadata.actors.values.filter((actor) => {
         const regex = new RegExp(/^((?![a-z]\d{1,3})).*/gim)
@@ -39,35 +67,49 @@ class CrowdSourcing extends Component {
         return val !== null
       })
       // Remove actors with generated, non-descritive names e.g. a201, h300
-      actors = filteredActors.map((actor) => {
+      unsortedActors = filteredActors.map((actor) => {
         const regex = new RegExp(/^((?![a-z]\d{1,3})).*/gim)
         const val = actor.value.match(regex)
         if(val !== undefined) {
           return actor.value.match(regex)
         }
       })
-
+      // Sort into groups
+      sortedActors = this.sortActors(unsortedActors)
 
     }
-    this.setState({actors: actors, actorsSet: true})
+    this.setState({actors: sortedActors, actorsSet: true})
   }
 
   render() {
+    const headings = [
+      'Actors', 'Harms and Violations', 'Rights and Freedoms', 'Principles and Values']
     // Only render if user has a uuid and the actors have been set.
     if(this.state.uuid && this.state.actorsSet) {
       let buttons = []
       // Each actor gets its own set of feedback buttons
-      this.state.actors.forEach((actor) => {
-        buttons.push(
-          <CrowdSourcingButton
-            actor={actor.join()}
-            doc={this.state.doc}
-            item={this.props.item}
-            marked={false}
-            key={buttons.length}
-          />
-        )
-      })
+      this.state.actors.forEach(
+        (group, index) => {
+          if(group.length > 0) {
+            buttons.push(
+              <h5 key={buttons.length}>{headings[index]}</h5>
+            )
+            group.forEach(
+              (actor) => {
+                buttons.push(
+                  <CrowdSourcingButton
+                    actor={actor.join()}
+                    doc={this.state.doc}
+                    item={this.props.item}
+                    marked={false}
+                    key={buttons.length}
+                  />
+                )
+              }
+            )
+          }
+        }
+      )
       return (
         <div className="crowdsourcing-buttons">{buttons}</div>
       )

--- a/src/components/Document/CrowdSourcing.jsx
+++ b/src/components/Document/CrowdSourcing.jsx
@@ -26,6 +26,8 @@ class CrowdSourcing extends Component {
       ]
     }
     this.sortActors = this.sortActors.bind(this)
+    this.headings = [
+      'Actors', 'Harms and Violations', 'Rights and Freedoms', 'Principles and Values']
   }
 
   componentWillMount() {
@@ -47,7 +49,7 @@ class CrowdSourcing extends Component {
       while (!assigned && index < sortedActors.length) {
         if(_.where(this.state.topicArrays[index], {name: actor.value.trim()}).length > 0) {
           assigned = true
-          sortedActors[index].push(actor.value.trim())
+          sortedActors[index].push({label: actor.value.trim(), category: this.headings[index]})
         }
         index += 1
       }
@@ -72,8 +74,7 @@ class CrowdSourcing extends Component {
   }
 
   render() {
-    const headings = [
-      'Actors', 'Harms and Violations', 'Rights and Freedoms', 'Principles and Values']
+
     // Only render if user has a uuid and the actors have been set.
     if(this.state.uuid && this.state.actorsSet) {
       let buttons = []
@@ -82,7 +83,7 @@ class CrowdSourcing extends Component {
         (group, index) => {
           if(group.length > 0) {
             buttons.push(
-              <h5 key={buttons.length}>{headings[index]}</h5>
+              <h5 key={buttons.length}>{this.headings[index]}</h5>
             )
             group.forEach(
               (actor) => {

--- a/src/components/Document/CrowdSourcingButton.jsx
+++ b/src/components/Document/CrowdSourcingButton.jsx
@@ -49,12 +49,12 @@ class CrowdSourcingButton extends Component {
       }
       return
     })
-
     let data = {
       collection_id: this.props.item.collection_id,
       document_title: this.props.doc.name,
       paragraph: this.props.item.shortDescription,
-      actor: this.props.actor,
+      feedback_topic: this.props.actor.label,
+      feedback_topic_category: this.props.actor.category,
       search_topics: searchTopics.join(),
       search_topics_human: searchTopicsHuman.join(),
       user_search: document.getElementById('searchBox').value,
@@ -111,7 +111,7 @@ class CrowdSourcingButton extends Component {
               title='Mark as poorly tagged.'
               style={this.fontStyle()}
             >thumb_down</FontIcon>
-          </button> {this.props.actor}
+          </button> {this.props.actor.label}
         </div>
       )
       } else {
@@ -120,7 +120,7 @@ class CrowdSourcingButton extends Component {
             <FontIcon
               className='material-icons'
               style={this.fontStyle(true)}
-            >{this.state.voteType}</FontIcon> {this.props.actor}
+            >{this.state.voteType}</FontIcon> {this.props.actor.label}
           </div>
         )
       }
@@ -128,7 +128,7 @@ class CrowdSourcingButton extends Component {
   }
 }
 CrowdSourcingButton.propTypes = {
-  actor: PropTypes.string.isRequired,
+  actor: PropTypes.object.isRequired,
   item: PropTypes.object.isRequired,
   marked: PropTypes.bool,
 }

--- a/src/components/Document/CrowdSourcingButton.jsx
+++ b/src/components/Document/CrowdSourcingButton.jsx
@@ -1,4 +1,3 @@
-'use strict'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types';
 import mui, {FontIcon} from 'material-ui';

--- a/src/modules/FlattenTreeToArray.js
+++ b/src/modules/FlattenTreeToArray.js
@@ -1,0 +1,9 @@
+module.exports = function flattenTreeToArray(topics, arr) {
+  for(var topic in topics) {
+    arr.push(topics[topic])
+    if(topics[topic].children) {
+      flattenTreeToArray(topics[topic].children, arr)
+    }
+  }
+  return arr
+}

--- a/src/modules/mapTermToHumanReadable.js
+++ b/src/modules/mapTermToHumanReadable.js
@@ -1,14 +1,5 @@
 import topics from '../components/Search/topics.js'
-
-function flattenTreeToArray(topics, arr) {
-  for(var topic in topics) {
-    arr.push(topics[topic])
-    if(topics[topic].children) {
-      flattenTreeToArray(topics[topic].children, arr)
-    }
-  }
-  return arr
-}
+import flattenTreeToArray from './FlattenTreeToArray.js'
 
 module.exports = function(term) {
   if(!window.flattenedTopics) {


### PR DESCRIPTION
Users need to understand which of the four sections a tag originates from.

Split crowdsourcing buttons into 4 groups, one for each topic level topic. Add a heading label to each group.

![screen shot 2018-07-25 at 11 57 24 am](https://user-images.githubusercontent.com/416559/43212434-ee6ed1fa-9001-11e8-8f27-0778cc84a596.png)

Google Sheets notes:
![screen shot 2018-07-25 at 2 42 15 pm](https://user-images.githubusercontent.com/416559/43220807-fac6c36a-9018-11e8-9f24-e2dca72ad3ba.png)
